### PR TITLE
fix #18 tvariable missingvalue copy issue in subRegion

### DIFF
--- a/Lib/tvariable.py
+++ b/Lib/tvariable.py
@@ -3,7 +3,7 @@
 
 """
 TransientVariable (created by createVariable)
-is a child of both AbstractVariable and the masked array class.
+is a  child of both AbstractVariable and the masked array class.
 Contains also the write part of the old cu interface.
 """
 import json

--- a/Lib/tvariable.py
+++ b/Lib/tvariable.py
@@ -152,7 +152,7 @@ class TransientVariable(AbstractVariable, numpy.ma.MaskedArray):
            The savespace argument is ignored, for backward compatibility only.
         """
         try:
-            if data.fill_value is not None:
+            if( (data.fill_value is not None) and (fill_value is None) ):
                 self._setmissing(data.fill_value)
                 fill_value = data.fill_value
         except:

--- a/Test/test_tvariable.py
+++ b/Test/test_tvariable.py
@@ -46,8 +46,7 @@ class TestTransientVariables(basetest.CDMSBaseTest):
         self.assertEqual(missing_value, -99.9)
 
         tmv = tv.fill_value
-        # TODO: Did the default value of fill_value/missing change? This is failing.
-        #self.assertEqual(tmv, -99.9)
+        self.assertEqual(tmv, -99.9)
 
         grid = tv.getGrid()
         self.assertFalse(grid is None)


### PR DESCRIPTION
Fix test_tvariable where missing_value was not copied properly when creating a sub region
https://github.com/UV-CDAT/cdms/blob/master/Test/test_tvariable.py#L50