### PR TITLE
Ken drs file

### DIFF
--- a/Lib/fvariable.py
+++ b/Lib/fvariable.py
@@ -28,6 +28,10 @@ class FileVariable(DatasetVariable):
             for attname, attval in cdunifobj.__dict__.items():
                 self.__dict__[attname] = attval
                 self.attributes[attname]=attval
+            if self.__dict__['missing_value'] == None:
+                self.__dict__['missing_value'] = numpy.ma.default_fill_value(self)
+                self.attributes['missing_value'] = numpy.ma.default_fill_value(self)  
+
         val = self.__cdms_internals__+['name_in_file',]
         self.___cdms_internals__ = val
 

--- a/Lib/fvariable.py
+++ b/Lib/fvariable.py
@@ -28,7 +28,7 @@ class FileVariable(DatasetVariable):
             for attname, attval in cdunifobj.__dict__.items():
                 self.__dict__[attname] = attval
                 self.attributes[attname]=attval
-            if self.__dict__['missing_value'] == None:
+            if self.__dict__['missing_value'] is None:
                 self.__dict__['missing_value'] = numpy.ma.default_fill_value(self)
                 self.attributes['missing_value'] = numpy.ma.default_fill_value(self)  
 

--- a/Test/test_all_formats.py
+++ b/Test/test_all_formats.py
@@ -1,4 +1,3 @@
-import pdb
 import cdms2
 import os
 import sys

--- a/Test/test_all_formats.py
+++ b/Test/test_all_formats.py
@@ -1,3 +1,4 @@
+import pdb
 import cdms2
 import os
 import sys
@@ -8,6 +9,8 @@ import basetest
 class TestFormats(basetest.CDMSBaseTest):
     def testPP(self):
         f = self.getDataFile('testpp.pp')
+        data=f['ps']
+        self.assertEqual(data.missing_value, -1.07374182e+09)
 
     def testHDF(self):
         if cdat_info.CDMS_INCLUDE_HDF == "yes":
@@ -15,13 +18,20 @@ class TestFormats(basetest.CDMSBaseTest):
 
     def testDRS(self):
         f = self.getDataFile("dvtest1.dic")
+        data = f['a']
+        self.assertEqual(data.missing_value, 1e20)
 
     def testDAP(self):
         f = cdms2.open('http://test.opendap.org/opendap/hyrax/data/nc/coads_climatology.nc')
+        data=f['SST']
+        self.assertEqual(data.missing_value, -1e34)
         f.close()
 
     def testGRIB2(self):
         f = self.getDataFile("testgrib2.ctl")
+        data=f['wvhgtsfc']
+        self.assertEqual(data.missing_value, 9.999e20)
+
 
 if __name__ == "__main__":
     basetest.run()


### PR DESCRIPTION
Make sure missing_value is set to numpy MaskedArray default fill_value when reading a file.  For some reasons, it seems that numpy 1.11 have changed this behavior.  Ken tells me that it used to work and this is no longer the case.  

I also change the test_all_formats to validate the missing_value.   