### PR TITLE
Adds support for **kwargs to MV2 operation classes

### DIFF
--- a/Lib/MV2.py
+++ b/Lib/MV2.py
@@ -74,9 +74,9 @@ class var_unary_operation:
         self.mafunc = mafunc
         self.__doc__ = mafunc.__doc__
 
-    def __call__ (self, a):
+    def __call__ (self, a, **kwargs):
         axes, attributes, id, grid = _extractMetadata(a)
-        maresult = self.mafunc(_makeMaskedArg(a))
+        maresult = self.mafunc(_makeMaskedArg(a), **kwargs)
         return TransientVariable(maresult, axes=axes, attributes=attributes, id=id, grid=grid)
 
 class var_unary_operation_with_axis:
@@ -86,10 +86,10 @@ class var_unary_operation_with_axis:
         """
         self.mafunc = mafunc
         self.__doc__ = mafunc.__doc__
-    def __call__ (self, a, axis=0):
+    def __call__ (self, a, axis=0, **kwargs):
         axis = _conv_axis_arg(axis)
         ta = _makeMaskedArg(a)
-        maresult = self.mafunc(ta, axis=axis)
+        maresult = self.mafunc(ta, axis=axis, **kwargs)
         axes, attributes, id, grid = _extractMetadata(a, omit=axis, omitall=(axis is None))
         return TransientVariable(maresult, axes=axes, attributes=attributes, id=id, grid=grid)
 
@@ -218,14 +218,14 @@ class var_binary_operation:
         self.mafunc = mafunc
         self.__doc__ = mafunc.__doc__
 
-    def __call__ (self, a, b):
+    def __call__ (self, a, b, **kwargs):
         id = "variable_%i" % TransientVariable.variable_count
         TransientVariable.variable_count+=1
         axes = commonDomain(a,b)
         grid = commonGrid(a,b,axes)
         ta = _makeMaskedArg(a)
         tb = _makeMaskedArg(b)
-        maresult = self.mafunc(ta,tb)
+        maresult = self.mafunc(ta,tb, **kwargs)
         return TransientVariable(maresult, axes=axes, grid=grid,no_update_from=True,id=id)
 
     def reduce (self, target, axis=0):
@@ -343,8 +343,10 @@ nonzero = var_unary_operation(numpy.ma.nonzero)
 around = var_unary_operation(numpy.ma.around)
 floor = var_unary_operation(numpy.ma.floor)
 ceil = var_unary_operation(numpy.ma.ceil)
-sometrue = var_unary_operation_with_axis(numpy.ma.sometrue)
-alltrue = var_unary_operation_with_axis(numpy.ma.alltrue)
+sometrue = var_unary_operation_with_axis(numpy.ma.any)
+any = sometrue
+alltrue = var_unary_operation_with_axis(numpy.ma.all)
+all = alltrue
 logical_not = var_unary_operation(numpy.ma.logical_not)
 divide.reduce = None
 remainder = var_binary_operation(numpy.ma.remainder)

--- a/Test/test_mv2.py
+++ b/Test/test_mv2.py
@@ -20,6 +20,29 @@ class TestMV2(basetest.CDMSBaseTest):
         self.other_u_file = f["u"]
         self.ones = MV2.ones(self.other_u_file.shape, numpy.float32, axes=self.other_u_file.getAxisList(), attributes=self.other_u_file.attributes, id=self.other_u_file.id)
 
+    def testKwargs(self):
+        # This test makes sure that kwargs are passed through in each of the types of operation
+        arr = numpy.full((3, 3), .65) * [range(i, i + 3) for i in range(3)]
+        # Test var_unary_operation
+        v = MV2.around(arr, decimals=1)
+        valid = numpy.array([
+            [0.0, 0.6, 1.3],
+            [0.6, 1.3, 2.0],
+            [1.3, 2.0, 2.6]
+        ])
+        self.assertTrue(MV2.allequal(v, valid))
+        xs = [1, -1, -1, 1]
+        ys = [1, 1, -1, -1]
+        angles = [numpy.pi / 4, 3 * numpy.pi / 4, -3 * numpy.pi / 4, -numpy.pi / 4]
+        test_arr = numpy.zeros(4)
+        # Test var_binary_operation
+        MV2.arctan2(ys, xs, out=test_arr)
+        self.assertFalse(MV2.allclose(test_arr, 0))
+        self.assertTrue(MV2.allequal(test_arr, angles))
+        # Test var_unary_operation_with_axis
+        values = numpy.tile(numpy.arange(2), 3)
+        self.assertEqual(len(MV2.sometrue(values, axis=0, keepdims=True).shape), len(values.shape))
+
     def testPowAndSqrt(self):
         vel = MV2.sqrt(self.u_file ** 2 + self.v_file ** 2)
         vel.id = 'velocity'


### PR DESCRIPTION
This PR adds support for arbitrary kwargs to the MV2 operation classes, to allow for some of the misc. keywords that some ufuncs from numpy have. I also changed over `sometrue()` and `alltrue()` to use `numpy.ma.any()` and `numpy.ma.all()`, since the `numpy.ma.sometrue` and `numpy.ma.alltrue()`  functions are old stubs sitting around that should be aliased to the `any` and `all` functions, but apparently aren't. I took a quick peek through the source, and they're doing the exact same thing, except that any and all take a couple of args that sometrue and alltrue don't.