### PR TITLE
Revisit run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
-       conda create -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python<3"
+       conda create -n py3 -c cdat/label/linatest -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
+       conda create -n py2 -c cdat/label/linatest -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python<3"
        if [ $(uname) == "Linux" ]; then
            conda install -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64
            conda install -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ aliases:
            conda install -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc
        fi
 
-  - &setup_cdms
-    name: setup_cdms
+  - &setup_cdms_ORIG
+    name: setup_cdms_ORIG
     command: |
        export PATH=$HOME/project/$WORKDIR/miniconda/bin:$PATH
        export UVCDAT_ANONYMOUS_LOG=False
@@ -49,6 +49,27 @@ aliases:
          LDSHARED="$CC -shared -pthread" python setup.py install
        else
          cp tests/dodsrccircleciDarwin $HOME/.dodsrc
+         python setup.py install
+       fi
+       source activate py2
+       rm -rf build
+       if [ $(uname) == "Linux" ];then
+         export LDSHARED="$CC -shared -pthread"
+         LDSHARED="$CC -shared -pthread" python setup.py install
+       else
+         python setup.py install
+       fi
+
+  - &setup_cdms
+    name: setup_cdms
+    command: |
+       export PATH=$HOME/project/$WORKDIR/miniconda/bin:$PATH
+       export UVCDAT_ANONYMOUS_LOG=False
+       source activate py3
+       if [ $(uname) == "Linux" ];then
+         export LDSHARED="$CC -shared -pthread"
+         LDSHARED="$CC -shared -pthread" python setup.py install
+       else
          python setup.py install
        fi
        source activate py2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -n py3 -c cdat/label/linatest -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
-       conda create -n py2 -c cdat/label/linatest -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python<3"
+       conda create -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
+       conda create -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python<3"
        if [ $(uname) == "Linux" ]; then
            conda install -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64
            conda install -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ aliases:
        source activate py3
        python run_tests.py --subdir -v2 
        PY3_RESULT=$?
-       echo "*** py3 test result: "${PY3_RESULT}
+       echo "**** py3 test result: "${PY3_RESULT}
        echo  $PY2_RESULT > $HOME/project/$WORKDIR/py2_result.txt
        echo  $PY3_RESULT > $HOME/project/$WORKDIR/py3_result.txt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
-       conda create -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 "python<3"
+       conda create -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
+       conda create -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 "python<3"
        if [ $(uname) == "Linux" ]; then
            conda install -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64
            conda install -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64
@@ -67,11 +67,11 @@ aliases:
        export UVCDAT_ANONYMOUS_LOG=False
        set -e
        source activate py2
-       python run_tests.py -v2 
+       python run_tests.py --subdir -v2 
        PY2_RESULT=$?
        echo "*** py2 test result: "${PY2_RESULT}
        source activate py3
-       python run_tests.py -v2 
+       python run_tests.py --subdir -v2 
        PY3_RESULT=$?
        echo "*** py3 test result: "${PY3_RESULT}
        echo  $PY2_RESULT > $HOME/project/$WORKDIR/py2_result.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,34 +32,6 @@ aliases:
            conda install -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc
        fi
 
-  - &setup_cdms_ORIG
-    name: setup_cdms_ORIG
-    command: |
-       export PATH=$HOME/project/$WORKDIR/miniconda/bin:$PATH
-       export UVCDAT_ANONYMOUS_LOG=False
-       source activate py3
-       mkdir $HOME/.esg
-       echo "Get ESGF certificates"
-       echo ${ESGF_PWD} | myproxyclient logon -s esgf-node.llnl.gov -p 7512 -t 12 -S -b -l ${ESGF_USER} -o $HOME/.esg/esgf.cert
-       echo "Create .dods_cookies"
-       curl -L  -v   -c $HOME/.esg/.dods_cookies --cert $HOME/.esg/esgf.cert  --key $HOME/.esg/esgf.cert "https://aims3.llnl.gov/thredds/dodsC/cmip5_css02_data/cmip5/output1/CMCC/CMCC-CM/decadal2005/mon/atmos/Amon/r1i1p1/cct/1/cct_Amon_CMCC-CM_decadal2005_r1i1p1_202601-203512.nc.dds"
-       if [ $(uname) == "Linux" ];then
-         cp tests/dodsrccircleciLinux $HOME/.dodsrc
-         export LDSHARED="$CC -shared -pthread"
-         LDSHARED="$CC -shared -pthread" python setup.py install
-       else
-         cp tests/dodsrccircleciDarwin $HOME/.dodsrc
-         python setup.py install
-       fi
-       source activate py2
-       rm -rf build
-       if [ $(uname) == "Linux" ];then
-         export LDSHARED="$CC -shared -pthread"
-         LDSHARED="$CC -shared -pthread" python setup.py install
-       else
-         python setup.py install
-       fi
-
   - &setup_cdms
     name: setup_cdms
     command: |
@@ -90,7 +62,7 @@ aliases:
        source activate py2
        python run_tests.py --subdir -v2 
        PY2_RESULT=$?
-       echo "*** py2 test result: "${PY2_RESULT}
+       echo "**** py2 test result: "${PY2_RESULT}
        source activate py3
        python run_tests.py --subdir -v2 
        PY3_RESULT=$?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,14 +22,14 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -n py3 -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
-       conda create -n py2 -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python<3"
+       conda create -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
+       conda create -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python<3"
        if [ $(uname) == "Linux" ]; then
-           conda install -n py3 -c cdat/label/nightly -c conda-forge gcc_linux-64
-           conda install -n py2 -c cdat/label/nightly -c conda-forge gcc_linux-64
+           conda install -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64
+           conda install -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64
        else
-           conda install -n py3 -c cdat/label/nightly -c conda-forge gcc
-           conda install -n py2 -c cdat/label/nightly -c conda-forge gcc
+           conda install -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc
+           conda install -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc
        fi
 
   - &setup_cdms

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ aliases:
        source activate py3
        python run_tests.py --subdir -v2 
        PY3_RESULT=$?
-       echo "**** py3 test result: "${PY3_RESULT}
+       echo "*** py3 test result: "${PY3_RESULT}
        echo  $PY2_RESULT > $HOME/project/$WORKDIR/py2_result.txt
        echo  $PY3_RESULT > $HOME/project/$WORKDIR/py3_result.txt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ aliases:
        conda update -y -q conda
        conda config --set anaconda_upload no
        conda create -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
-       conda create -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 "python<3"
+       conda create -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python<3"
        if [ $(uname) == "Linux" ]; then
            conda install -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64
            conda install -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,14 +22,14 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       conda create -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
-       conda create -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python<3"
+       conda create -n py3 -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python>3"
+       conda create -n py2 -c cdat/label/nightly -c conda-forge -c cdat libcf distarray cdtime libcdms cdat_info testsrunner numpy esmf esmpy libdrs_f pyopenssl nose requests flake8 myproxyclient "python<3"
        if [ $(uname) == "Linux" ]; then
-           conda install -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64
-           conda install -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc_linux-64
+           conda install -n py3 -c cdat/label/nightly -c conda-forge gcc_linux-64
+           conda install -n py2 -c cdat/label/nightly -c conda-forge gcc_linux-64
        else
-           conda install -n py3 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc
-           conda install -n py2 -c cdat/label/unstable -c cdat/label/nightly -c conda-forge gcc
+           conda install -n py3 -c cdat/label/nightly -c conda-forge gcc
+           conda install -n py2 -c cdat/label/nightly -c conda-forge gcc
        fi
 
   - &setup_cdms

--- a/run_tests.py
+++ b/run_tests.py
@@ -28,9 +28,10 @@ class CDMSTestRunner(cdat_info.TestRunnerBase):
                                                                cert=cert_opt,
                                                                key=key_opt,
                                                                dds=dds)
-        ret_code, out = run_command(cmd)
-        if ret_code != SUCCESS:
-            return ret_code
+        os.system(cmd)
+        #ret_code, out = run_command(cmd)
+        #if ret_code != SUCCESS:
+        #    return ret_code
         if sys.platform == 'darwin':
             cmd = "cp tests/dodsrccircleciDarwin {h}/.dodsrc".format(h=home)
         else:

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,291 +1,41 @@
-#!/usr/bin/env python
-from __future__ import print_function
-import shutil
-import glob
-import sys
 import os
-import argparse
-import multiprocessing
-import subprocess
-import codecs
-import time
-import webbrowser
-import shlex
+import sys
 import cdat_info
-import numpy.distutils
-import distutils
+import tempfile
 
-root = os.getcwd()
-cpus = multiprocessing.cpu_count()
+class CDMSTestRunner(cdat_info.TestRunnerBase):
+    def run(self, workdir, tests=None):
 
-parser = argparse.ArgumentParser(description="Run VCS tests",
-                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument("-H", "--html", action="store_true",
-                    help="create and show html result page")
-parser.add_argument("-p", "--package", action="store_true",
-                    help="package test results")
+        os.chdir(workdir)
+        test_names = super(CDMSTestRunner, self)._get_tests(workdir, self.args.tests)
 
-parser.add_argument(
-    "-c",
-    "--coverage",
-    action="store_true",
-    help="run coverage (not implemented)")
-parser.add_argument(
-    "-v",
-    "--verbosity",
-    default=1,
-    choices=[
-        0,
-        1,
-        2],
-    type=int,
-    help="verbosity output level")
-parser.add_argument(
-    "-n",
-    "--cpus",
-    default=cpus,
-    type=int,
-    help="number of cpus to use")
-parser.add_argument(
-    "-f",
-    "--failed-only",
-    action="store_true",
-    default=False,
-    help="runs only tests that failed last time and are in the list you provide")
-parser.add_argument("-s","--subdir",action="store_true",help="run in a subdirectory")
+        if self.args.checkout_baseline:
+            ret_code = super(CDMSTestRunner, self)._get_baseline(workdir)
+            if ret_code != SUCCESS:
+                return(ret_code)
 
-parser.add_argument("tests", nargs="*", help="tests to run")
+        if self.args.subdir:
+            tmpdir = tempfile.mkdtemp()
+            os.chdir(tmpdir)
+            ret_code = super(CDMSTestRunner, self)._do_run_tests(workdir, test_names)
+            os.chdir(workdir)
 
-args = parser.parse_args()
+        if self.args.html or self.args.package:
+            super(CDMSTestRunner, self)._generate_html(workdir)
+
+        if self.args.package:
+            super(CDMSTestRunner, self)._package_results(workdir)
+
+        return ret_code
 
 
-def abspath(path, name, prefix):
-    full_path = os.path.abspath(os.path.join(os.getcwd(), "..", path))
-    if not os.path.exists(name):
-        os.makedirs(name)
-    new = os.path.join(nm, prefix + "_" + os.path.basename(full_path))
-    try:
-        shutil.copy(full_path, new)
-    except:
-        pass
-    return new
+test_suite_name = 'cdms'
 
+workdir = os.getcwd()
+runner = CDMSTestRunner(test_suite_name, options=["--subdir"],
+                        options_files=["tests/cdms_runtests.json"],
+                        get_sample_data=True,
+                        test_data_files_info="share/test_data_files.txt")
+ret_code = runner.run(workdir)
 
-def findDiffFiles(log):
-    i = -1
-    file1 = ""
-    file2 = ""
-    diff = ""
-    N = len(log)
-    while log[i].find("Source file") == -1 and i > -N:
-        i -= 1
-    if i > -N:
-        file1 = log[i - 1].split()[-1]
-        for j in range(i, N):
-            if log[j].find("New best!") > -1:
-                if log[j].find("Comparing") > -1:
-                    file2 = log[j].split()[2]
-                else:
-                    k = j - 1
-                    while log[k].find("Comparing") == -1 and k > -N:
-                        k -= 1
-                    try:
-                        file2 = log[k].split()[2]
-                    except:
-                        file2 = log[k].split()[1][:-1]+log[j].split()[0]
-                        print(("+++++++++++++++++++++++++",file2))
-            if log[j].find("Saving image diff") > -1:
-                diff = log[j].split()[-1]
-                # break
-    return file1, file2, diff
-
-
-def run_command(command, join_stderr=True):
-    if isinstance(command, str):
-        command = shlex.split(command)
-    if args.verbosity > 0:
-        print("Executing %s in %s" % (" ".join(command), os.getcwd()))
-    if join_stderr:
-        stderr = subprocess.STDOUT
-    else:
-        stderr = subprocess.PIPE
-    P = subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=stderr,
-        bufsize=0,
-        cwd=os.getcwd())
-    out = []
-    while P.poll() is None:
-        read = P.stdout.readline().rstrip()
-        out.append(read)
-        if args.verbosity > 1 and len(read) != 0:
-            print(read)
-    return P, out
-
-
-def run_nose(test_name):
-    opts = []
-    if args.coverage:
-        opts += ["--with-coverage"]
-    command = ["nosetests", ] + opts + ["-s", test_name]
-    start = time.time()
-    P, out = run_command(command)
-    end = time.time()
-    return {test_name: {"result": P.poll(), "log": out, "times": {
-        "start": start, "end": end}}}
-
-
-sys.path.append(
-    os.path.join(
-        os.path.dirname(
-            os.path.abspath(__file__)),
-        "tests"))
-
-
-if len(args.tests) == 0:
-    names = glob.glob("tests/test_*.py")
-else:
-    names = set(args.tests)
-
-
-if args.failed_only and os.path.exists(os.path.join("tests",".last_failure")):
-    if not os.path.exists("tests"):
-        os.makedirs("tests")
-    f = open(os.path.join("tests",".last_failure"))
-    failed = set(eval(f.read().strip()))
-    f.close()
-    new_names = []
-    for fnm in failed:
-        if fnm in names:
-            new_names.append(fnm)
-    names = new_names
-
-if args.subdir:
-    import tempfile
-    tmpdir = tempfile.mkdtemp()
-    os.chdir(tmpdir)
-    names = [ os.path.join(root,t) for t in names]
-    print("RUNNNIG FROM:",tmpdir)
-
-if len(names)==0:
-    print("No tests to run")
-    sys.exit(0)
-
-if args.verbosity > 1:
-    print(("Names:", names))
-
-# Make sure we have sample data
-cdat_info.download_sample_data_files(os.path.join(distutils.sysconfig.get_python_lib(),"share","cdms2","test_data_files.txt"),cdat_info.get_sampledata_path())
-
-p = multiprocessing.Pool(args.cpus)
-outs = p.map(run_nose, names)
-results = {}
-failed = []
-for d in outs:
-    results.update(d)
-    nm = list(d.keys())[0]
-    if d[nm]["result"] != 0:
-        failed.append(nm)
-if args.subdir:
-    f = open(os.path.join(root,"tests",".last_failure"),"w")
-else:
-    f = open(os.path.join("tests",".last_failure"),"w")
-f.write(repr(failed))
-f.close()
-
-if args.verbosity > 0:
-    print("Ran %i tests, %i failed (%.2f%% success)" %\
-        (len(outs), len(failed), 100. - float(len(failed)) / len(outs) * 100.))
-    if len(failed) > 0:
-        print("Failed tests:")
-        for f in failed:
-            print("\t", f)
-if args.html or args.package:
-    if not os.path.exists("tests_html"):
-        os.makedirs("tests_html")
-    os.chdir("tests_html")
-
-    js = ""
-
-    fi = open("index.html", "w")
-    print("<!DOCTYPE html>", file=fi)
-    print("""<html><head><title>VCS Test Results %s</title>
-    <link rel="stylesheet" type="text/css" href="http://cdn.datatables.net/1.10.13/css/jquery.dataTables.css">
-    <script type="text/javascript" src="http://code.jquery.com/jquery-1.12.4.js"></script>
-    <script type="text/javascript" charset="utf8"
-    src="https://cdn.datatables.net/1.10.13/js/jquery.dataTables.min.js"></script>
-    <script>
-    $(document).ready( function () {
-            $('#table_id').DataTable({
-            "order":[[1,'asc'],[0,'asc']],
-            "scrollY":"70vh","paging":false,"scrollCollapse":false
-            });
-                } );
-    </script>
-    </head>""" % time.asctime(), file=fi)
-    print("<body><h1>VCS Test results: %s</h1>" % time.asctime(), file=fi)
-    print("<table id='table_id' class='display'>", file=fi)
-    print("<thead><tr><th>Test</th><th>Result</th><th>Start Time</th><th>End Time</th><th>Time</th></tr></thead>", file=fi)
-    print("<tfoot><tr><th>Test</th><th>Result</th><th>Start Time</th><th>End Time</th><th>Time</th></tr></tfoot>", file=fi)
-
-    for t in sorted(results.keys()):
-        result = results[t]
-        nm = t.split("/")[-1][:-3]
-        print("<tr><td>%s</td>" % nm, end=' ', file=fi)
-        fe = codecs.open("%s.html" % nm, "w", encoding="utf-8")
-        print("<!DOCTYPE html>", file=fe)
-        print("<html><head><title>%s</title>" % nm, file=fe)
-        if result["result"] == 0:
-            print("<td><a href='%s.html'>OK</a></td>" % nm, end=' ', file=fi)
-            print("</head><body>", file=fe)
-            print("<a href='index.html'>Back To Results List</a>", file=fe)
-        else:
-            print("<td><a href='%s.html'>Fail</a></td>" % nm, end=' ', file=fi)
-            print("<script type='text/javascript'>%s</script></head><body>" % js, file=fe)
-            print("<a href='index.html'>Back To Results List</a>", file=fe)
-            print("<h1>Failed test: %s on %s</h1>" % (nm, time.asctime()), file=fe)
-            file1, file2, diff = findDiffFiles(result["log"])
-            if file1 != "":
-                print('<div id="comparison"></div><script type="text/javascript"> ImageCompare.compare(' +\
-                    'document.getElementById("comparison"), "%s", "%s"); </script>' % (
-                        abspath(file2, nm, "test"), abspath(file1, nm, "source")), file=fe)
-                print("<div><a href='index.html'>Back To Results List</a></div>", file=fe)
-                print("<div id='diff'><img src='%s' alt='diff file'></div>" % abspath(
-                    diff, nm, "diff"), file=fe)
-                print("<div><a href='index.html'>Back To Results List</a></div>", file=fe)
-        print('<div id="output"><h1>Log</h1><pre>%s</pre></div>' % "\n".join(result[
-                                                                                  "log"]), file=fe)
-        print("<a href='index.html'>Back To Results List</a>", file=fe)
-        print("</body></html>", file=fe)
-        fe.close()
-        t = result["times"]
-        print("<td>%s</td><td>%s</td><td>%s</td></tr>" % (
-            time.ctime(t["start"]), time.ctime(t["end"]), t["end"] - t["start"]), file=fi)
-
-    print("</table></body></html>", file=fi)
-    fi.close()
-    if args.html:
-        webbrowser.open("file://%s/index.html" % os.getcwd())
-else:
-    if len(failed) == 0 and args.subdir:
-        print("Remving temp run dir: %s" % tmpdir)
-        os.chdir(root)
-        shutil.rmtree(tmpdir)
-
-if args.package:
-    import tarfile
-    os.chdir(tmpdir)
-    tnm = "results_%s_%s_%s.tar.bz2" % (os.uname()[0],os.uname()[1],time.strftime("%Y-%m-%d_%H:%M"))
-    t = tarfile.open(tnm, "w:bz2")
-    print("PATH TARRING FROM: %s" % os.getcwd())
-    t.add("tests_html")
-    t.add("tests_html")
-    t.close()
-    if args.verbosity > 0:
-        print("Packaged Result Info in:", tnm)
-
-if args.subdir and len(failed)!=0:
-    print("Do not removing to clean temp directory: %s" % tmpdir)
-os.chdir(root)
-sys.exit(len(failed))
+sys.exit(ret_code)

--- a/run_tests.py
+++ b/run_tests.py
@@ -14,7 +14,7 @@ class CDMSTestRunner(cdat_info.TestRunnerBase):
 
         esgf_pwd = os.environ["ESGF_PWD"]
         esgf_user = os.environ["ESGF_USER"]
-        cmd = "echo ${p} | myproxyclient logon -s esgf-node.llnl.gov -p 7512 -t 12 -S -b -l ${u} -o {h}/.esg/esgf.cert".format(p=esgf_pwd, u=esgf_user, h=home)
+        cmd = "echo {p} | myproxyclient logon -s esgf-node.llnl.gov -p 7512 -t 12 -S -b -l {u} -o {h}/.esg/esgf.cert".format(p=esgf_pwd, u=esgf_user, h=home)
         ret_code, out = run_command(cmd)
         if ret_code != 0:
             return ret_code

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,6 +4,8 @@ import cdat_info
 from testsrunner.Util import run_command
 import tempfile
 
+SUCCESS = 0
+
 class CDMSTestRunner(cdat_info.TestRunnerBase):
 
     def __setup_cdms(self):
@@ -26,7 +28,7 @@ class CDMSTestRunner(cdat_info.TestRunnerBase):
                                                                key=key_opt,
                                                                dds=dds)
         ret_code, out = run_command(cmd)
-        if ret_code != 0:
+        if ret_code != SUCCESS:
             return ret_code
         if sys.platform == 'darwin':
             cmd = "cp tests/dodsrccircleciDarwin {h}/.dodsrc".format(h=home)

--- a/run_tests.py
+++ b/run_tests.py
@@ -9,6 +9,14 @@ class CDMSTestRunner(cdat_info.TestRunnerBase):
     def __setup_cdms(self):
         home = os.environ["HOME"]
         os.mkdir("{h}/.esg".format(h=home))
+
+        esgf_pwd = os.environ["ESGF_PWD"]
+        esgf_user = os.environ["ESGF_USER"]
+        cmd = "echo ${p} | myproxyclient logon -s esgf-node.llnl.gov -p 7512 -t 12 -S -b -l ${u} -o {h}/.esg/esgf.cert".format(p=esgf_pwd, u=esgf_user, h=home)
+        ret_code, out = run_command(cmd)
+        if ret_code != 0:
+            return ret_code
+
         cookies = "-c {h}/.esg/.dods_cookies".format(h=home)
         cert_opt = "--cert {h}/.esg/esgf.cert".format(h=home)
         key_opt = "--key {h}/.esg/esgf.cert".format(h=home)

--- a/run_tests.py
+++ b/run_tests.py
@@ -9,7 +9,7 @@ class CDMSTestRunner(cdat_info.TestRunnerBase):
     def __setup_cdms(self):
         home = os.environ["HOME"]
         os.mkdir("{h}/.esg".format(h=home))
-        cookies_opt = "-c {h}/.esg/.dods_cookies".format(h=home)
+        cookies = "-c {h}/.esg/.dods_cookies".format(h=home)
         cert_opt = "--cert {h}/.esg/esgf.cert".format(h=home)
         key_opt = "--key {h}/.esg/esgf.cert".format(h=home)
         dds = "https://aims3.llnl.gov/thredds/dodsC/cmip5_css02_data/cmip5/output1/CMCC/CMCC-CM/decadal2005/mon/atmos/Amon/r1i1p1/cct/1/cct_Amon_CMCC-CM_decadal2005_r1i1p1_202601-203512.nc.dds"

--- a/run_tests.py
+++ b/run_tests.py
@@ -15,15 +15,16 @@ class CDMSTestRunner(cdat_info.TestRunnerBase):
         esgf_pwd = os.environ["ESGF_PWD"]
         esgf_user = os.environ["ESGF_USER"]
         cmd = "echo {p} | myproxyclient logon -s esgf-node.llnl.gov -p 7512 -t 12 -S -b -l {u} -o {h}/.esg/esgf.cert".format(p=esgf_pwd, u=esgf_user, h=home)
-        ret_code, out = run_command(cmd)
-        if ret_code != 0:
-            return ret_code
+        #ret_code, out = run_command(cmd)
+        #if ret_code != 0:
+        #    return ret_code
+        os.system(cmd)
 
         cookies = "-c {h}/.esg/.dods_cookies".format(h=home)
         cert_opt = "--cert {h}/.esg/esgf.cert".format(h=home)
         key_opt = "--key {h}/.esg/esgf.cert".format(h=home)
         dds = "https://aims3.llnl.gov/thredds/dodsC/cmip5_css02_data/cmip5/output1/CMCC/CMCC-CM/decadal2005/mon/atmos/Amon/r1i1p1/cct/1/cct_Amon_CMCC-CM_decadal2005_r1i1p1_202601-203512.nc.dds"
-        cmd = "curl -L -v {cookies} {cert} {key} {dds}".format(cookies=cookies,
+        cmd = "curl -L -v {cookies} {cert} {key} \"{dds}\"".format(cookies=cookies,
                                                                cert=cert_opt,
                                                                key=key_opt,
                                                                dds=dds)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import shutil
 import cdat_info
 from testsrunner.Util import run_command
 import tempfile
@@ -10,7 +11,10 @@ class CDMSTestRunner(cdat_info.TestRunnerBase):
 
     def __setup_cdms(self):
         home = os.environ["HOME"]
-        os.mkdir("{h}/.esg".format(h=home))
+        esg_dir = "{h}/.esg".format(h=home)
+        if os.path.isdir(esg_dir):
+            shutil.rmtree(esg_dir)
+        os.mkdir(esg_dir)
 
         esgf_pwd = os.environ["ESGF_PWD"]
         esgf_user = os.environ["ESGF_USER"]

--- a/tests/cdms_runtests.json
+++ b/tests/cdms_runtests.json
@@ -1,0 +1,8 @@
+{
+    "--subdir": {
+        "action": "store_true",
+        "default": true,
+        "help": "specifies if tests should be run in a subdir",
+	"type": null
+    }
+}

--- a/tests/coverage.json
+++ b/tests/coverage.json
@@ -1,4 +1,0 @@
-{
-   "include": ["cdms2", "regrid2", "cdtime", "cdat_info", "testsrunner"]
-}
-

--- a/tests/coverage.json
+++ b/tests/coverage.json
@@ -1,0 +1,4 @@
+{
+   "include": ["cdms2", "regrid2", "cdtime", "cdat_info", "testsrunner"]
+}
+


### PR DESCRIPTION
migrate run_tests.py to use TestRunnerBase.py
One test case is failing tests_all_formats.py (failed like in nightly).
I hope I still can get this PR merged because it helps me in viewing the test result of nightly.
with this new run_tests.py, if there is a failure in the test run, it will generate .failed_tests.html
under tests_html artifacts.
