### PR TITLE
pin libnetcdf 4.6.2 for cdat 8.2

### DIFF
--- a/recipe/meta.yaml.in
+++ b/recipe/meta.yaml.in
@@ -26,25 +26,26 @@ requirements:
     - libdrs_f
     - libdrs
     - cdtime
+    - openblas
     - lazy-object-proxy
-    - libnetcdf
+    - libnetcdf 4.6.2
   run:
     - python {{ python }}
     - libcf
     - distarray
     - lazy-object-proxy
     - cdtime
-    - cdat_info >=8.2
+    - cdat_info
     - {{ pin_compatible('numpy') }}
     - esmf
     - esmpy
     - six
-    - libcdms >=3.1.2
-    - libdrs_f >=3.1.2
-    - libdrs >=3.1.2
-    - cdtime >=3.1.2
+    - libcdms
+    - libdrs_f
+    - libdrs
+    - cdtime
     - openblas
-    - libnetcdf
+    - libnetcdf 4.6.2
 
 test:
   commands:


### PR DESCRIPTION
added libnetcdf 4.6.2 in recipe/meta.yaml.in 