### PR TITLE
py38, fixed test_cdscan.py and test_all_formats.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ aliases:
   - &setup_run_tests
     name: setup_run_tests
     environment:
-       PKGS: "testsrunner pytest myproxyclient"
+       PKGS: "testsrunner pytest"
        CHANNELS: "-c cdat/label/nightly -c conda-forge"
     command: |
        source $WORKDIR/miniconda/etc/profile.d/conda.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ aliases:
     name: setup_miniconda
     command: |
        mkdir -p workspace
-       git clone -b validateNightly git@github.com:CDAT/cdat workspace/cdat
+       git clone -b validateNightlyNew git@github.com:CDAT/cdat workspace/cdat
        # install_miniconda.py installs miniconda3 under $WORKDIR/miniconda
        python workspace/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3'
 
@@ -51,7 +51,6 @@ aliases:
        python run_tests.py -H -v2 -n 1 `pwd`/tests/test_big_array.py
        mv tests/test_big_array.py $WORKDIR/
        python run_tests.py -H -v2 --subdir $COVERAGE
-
     no_output_timeout: 60m
 
   - &conda_upload
@@ -77,7 +76,7 @@ aliases:
 jobs:
    macos_setup:
       macos:
-         xcode: "11.3.0"
+         xcode: "11.4.0"
       environment:
          WORKDIR: /Users/distiller/project/macos_build
          PKG_NAME: "cdms2"
@@ -109,16 +108,16 @@ jobs:
               paths:
                  - linux_build
 
-   macos_cdms_py2:
+   macos_cdms_py36:
       macos:
-         xcode: "11.3.0"
+         xcode: "11.4.0"
       environment:
          WORKDIR: /Users/distiller/project/macos_build
          PKG_NAME: "cdms2"
          REPO_NAME: "cdms"
          ENV_NAME: "test_cdms"
-         CONDA_PY_VER: "python<3"
-         BUILD_VARIANT_VER: "2.7"
+         CONDA_PY_VER: "python>=3.6,<3.7"
+         BUILD_VARIANT_VER: "3.6"
       steps:
          - checkout
          - attach_workspace:
@@ -136,7 +135,7 @@ jobs:
 
    macos_cdms_py37:
       macos:
-         xcode: "11.3.0"
+         xcode: "11.4.0"
       environment:
          WORKDIR: /Users/distiller/project/macos_build
          PKG_NAME: "cdms2"
@@ -159,7 +158,32 @@ jobs:
               paths:
                  - macos_build/miniconda/conda-bld/osx-64/cdms*tar.bz2
 
-   linux_cdms_py2:
+   macos_cdms_py38:
+      macos:
+         xcode: "11.4.0"
+      environment:
+         WORKDIR: /Users/distiller/project/macos_build
+         PKG_NAME: "cdms2"
+         REPO_NAME: "cdms"
+         ENV_NAME: "test_cdms"
+         CONDA_PY_VER: "python>=3.8,<3.9"
+         BUILD_VARIANT_VER: "3.8"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *conda_build
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+         - persist_to_workspace:
+              root: .
+              paths:
+                 - macos_build/miniconda/conda-bld/osx-64/cdms*tar.bz2
+
+   linux_cdms_py36:
       machine:
          image: circleci/classic:latest
       environment:
@@ -167,8 +191,8 @@ jobs:
          PKG_NAME: "cdms2"
          REPO_NAME: "cdms"
          ENV_NAME: "test_cdms"
-         CONDA_PY_VER: "python<3"
-         BUILD_VARIANT_VER: "2.7"
+         CONDA_PY_VER: "python>=3.6,<3.7"
+         BUILD_VARIANT_VER: "3.6"
       steps:
          - checkout
          - attach_workspace:
@@ -212,6 +236,31 @@ jobs:
               paths:
                  - linux_build/miniconda/conda-bld/linux-64/cdms*tar.bz2
 
+   linux_cdms_py38:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         WORKDIR: /home/circleci/project/linux_build
+         PKG_NAME: "cdms2"
+         REPO_NAME: "cdms"
+         ENV_NAME: "test_cdms"
+         CONDA_PY_VER: "python>=3.8,<3.9"
+         BUILD_VARIANT_VER: "3.8"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *conda_build
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+         - persist_to_workspace:
+              root: .
+              paths:
+                 - linux_build/miniconda/conda-bld/linux-64/cdms*tar.bz2
+
    upload:
       machine:
          image: circleci/classic:latest
@@ -233,21 +282,30 @@ workflows:
       jobs:
          - macos_setup
          - linux_setup
-         - macos_cdms_py2:
+         - macos_cdms_py36:
               requires:
                  - macos_setup
          - macos_cdms_py37:
               requires:
                  - macos_setup
-         - linux_cdms_py2:
+         - macos_cdms_py38:
+              requires:
+                 - macos_setup
+         - linux_cdms_py36:
               requires:
                  - linux_setup
          - linux_cdms_py37:
               requires:
                  - linux_setup
+         - linux_cdms_py38:
+              requires:
+                 - linux_setup
          - upload:
               requires:
-                 - macos_cdms_py2
+                 - macos_cdms_py36
                  - macos_cdms_py37
-                 - linux_cdms_py2
+                 - macos_cdms_py38
+                 - linux_cdms_py36
                  - linux_cdms_py37
+                 - linux_cdms_py38
+

--- a/run_tests.py
+++ b/run_tests.py
@@ -8,17 +8,12 @@ from testsrunner.Util import run_command
 import tempfile
 
 SUCCESS = 0
+FAILURE = 1
 
 class CDMSTestRunner(cdat_info.TestRunnerBase):
 
     def __setup_cdms(self):
         home = os.environ["HOME"]
-        esg_dir = "{h}/.esg".format(h=home)
-        if os.path.isdir(esg_dir):
-            shutil.rmtree(esg_dir)
-        os.mkdir(esg_dir)
-
-        # check if we are running tests from within the lab.
         hostname = socket.gethostname()
         cacert_pem = ""
         if hostname.endswith('.llnl.gov'):
@@ -30,48 +25,27 @@ class CDMSTestRunner(cdat_info.TestRunnerBase):
 
             python_ver = "python{a}.{i}".format(a=sys.version_info.major,
                                                 i=sys.version_info.minor)
-            coverage_opts = ""
             dest = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages', 'certifi', 'cacert.pem')
             cmd = "cat {h}/cspca.cer >> {dest}".format(h=home, dest=dest)
             cacert_pem = "--cacert {cacert}".format(cacert=dest)
 
-        esgf_pwd = os.environ["ESGF_PWD"]
-        esgf_user = os.environ["ESGF_USER"]
-
-        cookies = "-c {h}/.esg/.dods_cookies".format(h=home)
-        cert_opt = "--cert {h}/.esg/esgf.cert".format(h=home)
-        key_opt = "--key {h}/.esg/esgf.cert".format(h=home)
         ESGFINFO = {"https://aims3.llnl.gov/thredds/dodsC/cmip5_css01_data/cmip5/output1/BCC/bcc-csm1-1-m/1pctCO2/day/ocean/day/r1i1p1/v20120910/tos/tos_day_bcc-csm1-1-m_1pctCO2_r1i1p1_02800101-02891231.nc": "esgf-node.llnl.gov",
         "https://esg1.umr-cnrm.fr/thredds/dodsC/CMIP5_CNRM/output1/CNRM-CERFACS/CNRM-CM5/historical/day/atmos/day/r5i1p1/v20120703/huss/huss_day_CNRM-CM5_historical_r5i1p1_20050101-20051231.nc": "esg1.umr-cnrm.fr", 
         "https://esgf-node.cmcc.it/thredds/dodsC/esg_dataroot/cmip5/output1/CMCC/CMCC-CM/decadal1960/6hr/atmos/6hrPlev/r1i1p1/v20170725/psl/psl_6hrPlev_CMCC-CM_decadal1960_r1i1p1_1990120100-1990123118.nc": "esgf-node.cmcc.it"}
-        
-        passed = False
+        rc = FAILURE
         for file in ESGFINFO.keys():
             site = ESGFINFO[file]
-            cmd = "echo {p} | myproxyclient logon -s {s} -p 7512 -t 12 -S -b -l {u} -o {h}/.esg/esgf.cert".format(s=site, p=esgf_pwd, u=esgf_user, h=home)
-            rc = os.system(cmd)
-            if rc != 0:
-               continue
             dds = file + ".dds"
-            cmd = "curl -L -v {cacert} {cookies} {cert} {key} \"{dds}\"".format(cacert=cacert_pem,
-                                                                                cookies=cookies,
-                                                                                cert=cert_opt,
-                                                                                key=key_opt,
-                                                                                dds=dds)
+            fname = os.path.basename(file)
+            cmd = "curl -L -v {cacert} {source} -o {dest}".format(cacert=cacert_pem,
+                                                                  source=dds,
+                                                                  dest=fname)
             print("CMD: {cmd}".format(cmd=cmd))
             rc = os.system(cmd)
-            if rc == 0:
-                passed = True
+            if rc == SUCCESS:
                 break
 
-        if passed == False:
-            raise Exception("Can't get certificates from any ESGF sites")
-        if sys.platform == 'darwin':
-            cmd = "cp tests/dodsrccircleciDarwin {h}/.dodsrc".format(h=home)
-        else:
-            cmd = "cp tests/dodsrccircleciLinux {h}/.dodsrc".format(h=home)
-        ret_code, out = run_command(cmd)
-        return ret_code
+        return(rc)
 
     def run(self, workdir, tests=None):
 
@@ -81,7 +55,7 @@ class CDMSTestRunner(cdat_info.TestRunnerBase):
         ret_code = self.__setup_cdms()
         if ret_code != SUCCESS:
             return(ret_code)
-
+        #print("XXX after returning from __setup_cdms()")
         if self.args.checkout_baseline:
             ret_code = super(CDMSTestRunner, self)._get_baseline(workdir)
             if ret_code != SUCCESS:

--- a/tests/test_all_formats.py
+++ b/tests/test_all_formats.py
@@ -40,16 +40,6 @@ class TestFormats(basetest.CDMSBaseTest):
 
     # test disabled due to OSX issue
     def testESGF(self):
-        file = open(os.environ['HOME']+'/.dodsrc', 'w')
-        file.write("HTTP.VERBOSE=0\n")
-        file.write("HTTP.COOKIEJAR=" +
-                   os.environ['HOME']+"/.esg/.dods_cookies\n")
-        file.write("HTTP.SSL.CERTIFICATE=" +
-                   os.environ['HOME']+"/.esg/esgf.cert\n")
-        file.write("HTTP.SSL.KEY="+os.environ['HOME']+"/.esg/esgf.cert\n")
-        file.write("HTTP.SSL.CAPATH="+os.environ['HOME']+"/.esg/\n")
-        file.close()
-        f = None
         ESGFINFO = {"https://esg1.umr-cnrm.fr/thredds/dodsC/CMIP5_CNRM/output1/CNRM-CERFACS/CNRM-CM5/historical/day/atmos/day/r5i1p1/v20120703/huss/huss_day_CNRM-CM5_historical_r5i1p1_20050101-20051231.nc": "huss",
             "https://esgf-node.cmcc.it/thredds/dodsC/esg_dataroot/cmip5/output1/CMCC/CMCC-CM/decadal1960/6hr/atmos/6hrPlev/r1i1p1/v20170725/psl/psl_6hrPlev_CMCC-CM_decadal1960_r1i1p1_1990120100-1990123118.nc": "psl", "https://aims3.llnl.gov/thredds/dodsC/cmip5_css01_data/cmip5/output1/BCC/bcc-csm1-1-m/1pctCO2/day/ocean/day/r1i1p1/v20120910/tos/tos_day_bcc-csm1-1-m_1pctCO2_r1i1p1_02800101-02891231.nc": "tos"}
         passed = False

--- a/tests/test_cdscan.py
+++ b/tests/test_cdscan.py
@@ -56,14 +56,23 @@ class TestCDScan(basetest.CDMSBaseTest):
         '''
         retrieve value from cdscan 
         '''
-        argv = 'cdscan -x test_dap.xml https://dataserver.nccs.nasa.gov/thredds/dodsC/bypass/CREATE-IP/Reanalysis/NASA-GMAO/GEOS-5/MERRA/mon/atmos/zg.ncml'.split()
-        pth = cdat_info.get_sampledata_path()
+        data_file1 = "https://dpesgf03.nccs.nasa.gov/thredds/dodsC/CREATE-IP/reanalysis/NASA-GMAO/GEOS-5/MERRA/mon/atmos/cl/cl_Amon_reanalysis_MERRA_197901-197912.nc"
+        data_file2 = "https://dpesgf03.nccs.nasa.gov/thredds/dodsC/CREATE-IP/reanalysis/NASA-GMAO/GEOS-5/MERRA/mon/atmos/cl/cl_Amon_reanalysis_MERRA_198001-198012.nc"
+        f1 = cdms2.open(data_file1)
+        f2 = cdms2.open(data_file2)
+        cl1 = f1["cl"]
+        cl2 = f2["cl"]
 
+        argv = "cdscan -x test_dap.xml {f1} {f2}".format(f1=data_file1,
+                                                         f2=data_file2).split()
+        pth = cdat_info.get_sampledata_path()
         os.chdir(pth)
         cdscan(argv)
         f=cdms2.open("test_dap.xml")
-        s=f['zg']
-        self.assertAlmostEqual(s[0,0,0,0], -73.563,3)
+        s=f['cl']
+        self.assertEqual(cl1[5, 20, 80, 140], s[5, 20, 80, 140])
+        self.assertEqual(cl2[5, 20, 80, 140], s[17, 20, 80, 140])
+
         os.unlink("test_dap.xml")
 
 if __name__ == "__main__":


### PR DESCRIPTION
+ updated .circleci/config.yml - drop py2 and build for py36, py37 and py38.
+ updated run_tests.py - data files are not protected anymore, no need to run myproxylogon.
+ updated test_cdscan.py -- use a different test files since dataserver.nccs.nasa.gov's state is not clear and updated the testopenfile()