### PR TITLE
Fixes error message for read-only attributes

### DIFF
--- a/Lib/__init__.py
+++ b/Lib/__init__.py
@@ -4,6 +4,7 @@ CDMS module-level API
 
 # Errors
 from .error import CDMSError  # noqa
+from .Cdunif import ReadOnlyKeyError
 from lazy_object_proxy import Proxy
 from . import dataset
 from . import selectors

--- a/Lib/__init__.py
+++ b/Lib/__init__.py
@@ -4,7 +4,8 @@ CDMS module-level API
 
 # Errors
 from .error import CDMSError  # noqa
-from .Cdunif import ReadOnlyKeyError
+from .error import CdunifError  # noqa
+from .error import ReadOnlyKeyError  # noqa
 from lazy_object_proxy import Proxy
 from . import dataset
 from . import selectors
@@ -138,5 +139,3 @@ try:
     from . import dask_protocol  # noqa
 except BaseException:
     pass
-
-from .Cdunif import CdunifError

--- a/Lib/dataset.py
+++ b/Lib/dataset.py
@@ -2105,7 +2105,13 @@ class CdmsFile(CdmsObj, cuDataset):
             if attname not in ["id", "datatype", "parent"]:
                 if isinstance(attval, string_types):
                     attval = str(attval)
-                setattr(newvar, str(attname), attval)
+                try:
+                    setattr(newvar, str(attname), attval)
+                except Cdunif.ReadOnlyKeyError as e:
+                    # Suppress the exception context
+                    err = "Cannot write read-only attribute '{!s}', must be " \
+                        "removed from '{!s}' variable before writing to file".format(e, var.id)
+                    raise CDMSError(err) from None
                 if (attname == "_FillValue") or (attname == "missing_value"):
                     setattr(newvar, "_FillValue", attval)
                     setattr(newvar, "missing_value", attval)

--- a/Lib/error.py
+++ b/Lib/error.py
@@ -1,3 +1,5 @@
 "Error object for cdms module"
 
 from .Cdunif import CDMSError  # noqa: F401
+from .Cdunif import CdunifError  # noqa: F401
+from .Cdunif import ReadOnlyKeyError  # noqa: F401

--- a/Lib/fvariable.py
+++ b/Lib/fvariable.py
@@ -157,12 +157,7 @@ class FileVariable(DatasetVariable):
         if hasattr(self, "parent") and self.parent is None:
             raise CDMSError(FileClosedWrite + self.id)
         if (name not in self.__cdms_internals__) and (value is not None):
-            try:
-                setattr(self._obj_, str(name), value)
-            except Exception:
-                raise CDMSError(
-                    "Setting %s.%s=%s" %
-                    (self.id, name, repr(value)))
+            setattr(self._obj_, str(name), value)
             self.attributes[name] = value
         self.__dict__[name] = value
 

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,14 @@ build: install-conda prep-feedstock create-conda-env
 				 EXTRA_CB_OPTIONS='--croot $(LOCAL_CHANNEL_DIR)' \
 				 $(SCRIPTS_DIR)/build_steps.sh | tee $(WORK_DIR)/`cat $(PWD)/.variant`
 
+.PHONY: build-env
+build-env:
+	$(CONDA_ENV); \
+		$(CONDA_ACTIVATE) base; \
+		$(CONDA_RC); \
+		conda activate build; \
+		bash
+
 .PHONY: build-docs
 build-docs: ENV := docs
 build-docs: CHANNELS := -c file://$(LOCAL_CHANNEL_DIR) -c conda-forge
@@ -118,6 +126,7 @@ clean-docs:
 .PHONY: test
 test: ENV := test
 test: CHANNELS := -c file://$(LOCAL_CHANNEL_DIR) -c conda-forge -c cdat/label/nightly
+test: CONDA_TEST_PACKAGES += nco
 test: create-conda-env
 	[[ ! -e "$(TEST_OUTPUT_DIR)" ]] && mkdir -p $(TEST_OUTPUT_DIR) || true
 
@@ -133,6 +142,18 @@ test: create-conda-env
 		python run_tests.py -H -v2 -n 1
 
 	cp -rf $(PWD)/tests_html $(TEST_OUTPUT_DIR)/
+
+.PHONY: test-env
+test-env:
+	$(CONDA_ENV); \
+		$(CONDA_ACTIVATE) base; \
+		$(CONDA_RC); \
+		conda activate test; \
+		bash
+
+.PHONY: test-clean
+test-clean:
+	rm -rf $(ENVS_DIR)/test
 
 .PHONY: upload
 upload: ENV := upload

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ label ?= nightly
 
 build_script = conda-recipes/build_tools/conda_build.py
 
-test_pkgs = testsrunner pytest 
+test_pkgs = testsrunner pytest nco
 last_stable ?= 3.1.4
 
 conda_build_env ?= build-$(pkg_name)

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,6 @@ clean-docs:
 .PHONY: test
 test: ENV := test
 test: CHANNELS := -c file://$(LOCAL_CHANNEL_DIR) -c conda-forge -c cdat/label/nightly
-test: CONDA_TEST_PACKAGES += nco
 test: create-conda-env
 	[[ ! -e "$(TEST_OUTPUT_DIR)" ]] && mkdir -p $(TEST_OUTPUT_DIR) || true
 
@@ -135,7 +134,7 @@ test: create-conda-env
 		$(CONDA_RC); \
 		conda config --set channel_priority strict; \
 		conda activate $(ENV); \
-		conda install --yes $(CHANNELS) cdms2 testsrunner cdat_info pytest pip \
+		conda install --yes $(CHANNELS) cdms2 testsrunner cdat_info pytest pip nco \
 		$(CONDA_TEST_PACKAGES); \
 		conda info; \
 		conda list --explicit > $(TEST_OUTPUT_DIR)/environment.txt; \


### PR DESCRIPTION
Fixes #408.

- Adds new exception `ReadOnlyKeyError`.
- Raises `ReadOnlyKeyError` when setting certain attributes on file-backed variable/dataset.
- Fixes raising error when read-only attribute is present in source variable being written to a file.