### PR TITLE
Fix CI errors and simplify makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ aliases:
 
       ./miniconda.sh -b -p ${MINICONDA_DIR}
 
+      ls -la .
+
       ls -la ${MINICONDA_DIR}
 
       source ${MINICONDA_DIR}/etc/profile.d/conda.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,16 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: ls -la build_artifacts/
+      - checkout:
+          path: cdms
+      - run: |
+        command:
+          export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+
+          cd cdms/
+
+          make upload CONDA_TOKEN=${CONDA_TEST_TOKEN} CONDA_USER=${CONDA_USER} \
+            CONDA_UPLOAD_ARGS="--force --label nightly"
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ aliases:
       source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 
       conda activate base
-      conda config --system --remove-key pkgs_dirs || exit 0
+      conda config --system --remove-key pkgs_dirs || true
       conda config --system --append pkgs_dirs ${CONDA_PKG_DIR}
       
       conda info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
           command: |
             export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
 
-            cp -ef ${WORK_DIR}/build_artifacts ${WORK_DIR}/local_conda_channel
+            cp -rf ${WORK_DIR}/build_artifacts ${WORK_DIR}/local_conda_channel
             source ${WORK_DIR}/miniconda/etc/profile.d/conda.sh
             conda activate base
             conda index ${WORK_DIR}/local_conda_channel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,5 +43,3 @@ workflows:
             parameters:
               os: [ linux, macos ]
           name: build-<< matrix.os >>
-          requires:
-            - prep-host-<< matrix.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,16 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: ls -la build_artifacts/
+      - checkout:
+          path: cdms
+      - run:
+          command: |
+            export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+
+            cd cdms/
+
+            make upload CONDA_TOKEN=${CONDA_TEST_TOKEN} CONDA_USER=${CONDA_USER} \
+              CONDA_UPLOAD_ARGS="--force --label nightly"
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
           paths:
             - cdms
             - conda-bld
+            - miniconda
             - build_artifacts
       - save_cache:
           paths:
@@ -69,6 +70,7 @@ jobs:
             # Prevent errors when merging workspaces for upload
             rm -rf ${WORK_DIR}/cdms
             rm -rf ${WORK_DIR}/conda-bld
+            rm -rf ${WORK_DIR}/miniconda
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,17 +29,19 @@ jobs:
 
             popd
 
-            mkdir -p build_artifacts/
+            mkdir -p ${WORK_DIR}/build_artifacts/
 
             cp ${WORK_DIR}/conda-bld/**/*.tar.bz2 ${WORK_DIR}/build_artifacts/
       - persist_to_workspace:
           root: .
           paths:
             - cdms
-            - miniconda
-            - pkgs
             - conda-bld
             - build_artifacts
+      - save_cache:
+          paths:
+            - pkgs
+          key: conda-pkgs-{{ arch }}
   test:
     parameters:
       os:
@@ -48,6 +50,8 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - restore_cache:
+          key: conda-pkgs-{{ arch }} 
       - run:
           command: |
             export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
@@ -56,14 +60,23 @@ jobs:
 
             make test
 
-            mkdir -p ${WORK_DIR}/test_artifacts/`make list-config`
+            export TEST_ARTIFACTS=${WORK_DIR}/test_artifacts/`make list-config`
+            
+            mkdir -p ${TEST_ARTIFACTS}
 
-            cp -rf  tests_html/* ${WORK_DIR}/test_artifacts/`make list-config`
+            cp -rf tests_html/* ${TEST_ARTIFACTS}
+
+            # Prevent errors when merging workspaces for upload
+            rm -rf ${WORK_DIR}/cdms
+            rm -rf ${WORK_DIR}/conda-bld
       - persist_to_workspace:
           root: .
           paths:
-            - build_artifacts
             - test_artifacts
+      - save_cache:
+          paths:
+            - pkgs
+          key: conda-pkgs-{{ arch }}
 
   upload:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,8 @@ jobs:
 
             cd cdms
 
+            ls -la ../feedstock/.ci_support/
+
             make list-configs
             make build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,13 @@ aliases:
 
       chmod +x miniconda.sh
 
-      ./miniconda.sh -b -p ${CIRCLE_WORKING_DIRECTORY}/miniconda
+      ./miniconda.sh -b -p ${MINICONDA_DIR}
+
+      source ${MINICONDA_DIR}/etc/profile.d/conda.sh
+
+      conda activate base
+
+      conda info
 
 executors:
   linux:
@@ -29,10 +35,13 @@ jobs:
       os:
         type: executor
     executor: << parameters.os >>
+    environment:
+      MINICONDA_DIR: ${CIRCLE_WORKING_DIRECTORY}/miniconda
     steps:
       - attach_workspace:
           at: .
-      - checkout
+      - checkout:
+          path: cdms
       - run: *setup_miniconda
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ jobs:
 
             cd cdms/
 
-            make upload CONDA_TOKEN=${CONDA_UPLOAD_TOKEN} \
-              CONDA_USER=cdat \
+            make upload CONDA_TOKEN=${CONDA_TEST_TOKEN} \
+              CONDA_USER=${CONDA_USER} \
               CONDA_UPLOAD_ARGS="--force --label nightly" \
               LOCAL_CHANNEL_DIR=${WORK_DIR}/build_artifacts
 
@@ -147,6 +147,3 @@ workflows:
           name: upload
           requires:
             - test
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ aliases:
 
       ./miniconda.sh -b -p ${MINICONDA_DIR}
 
-      ls -la ${MINICODNA_DIR}
+      ls -la ${MINICONDA_DIR}
 
       source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,8 @@ jobs:
         type: executor
       py:
         type: string
+      libnetcdf:
+        type: string
     executor: << parameters.os >>
     steps:
       - attach_workspace:
@@ -90,7 +92,7 @@ jobs:
 
             make test \
               LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel \
-              CONDA_TEST_PACKAGES="python=<< parameters.py >>" \
+              CONDA_TEST_PACKAGES="python=<< parameters.py >> << parameters.libnetcdf >>" \
               TEST_OUTPUT_DIR="${WORK_DIR}/test_results" 
 
             ls -la "${WORK_DIR}/sample_data"
@@ -140,7 +142,8 @@ workflows:
             parameters:
               os: [ linux, macos ]
               py: [ "3.6", "3.7", "3.8" ]
-          name: test-<<matrix.os>>-<< matrix.py >>
+              libnetcdf: [ "nompi", "mpich", "openmpi" ]
+          name: test-<<matrix.os>>-<< matrix.py >>-<< matrix.libnetcdf >>
           requires:
             - build-<< matrix.os >>-<< matrix.py >>
       - upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
 
             make test \
               LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel \
-              CONDA_TEST_PACKAGES="python=<< parameters.py >> << parameters.libnetcdf >>" \
+              CONDA_TEST_PACKAGES="<< parameters.libnetcdf >>" \
               TEST_OUTPUT_DIR="${WORK_DIR}/test_results" 
 
             ls -la "${WORK_DIR}/sample_data"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 
+executors:
+  linux:
+    machine:
+      image: circleci/classic:latest
+  macos:
+    macos:
+      xcode: "11.4.0"
+
 jobs:
   prep_host:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,9 @@ jobs:
       - run: *setup_miniconda
       - persist_to_workspace
           root: .
+          paths:
+            - miniconda
+            - cdms
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - checkout:
+          path: cdms
       - run:
           command: |
             export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
@@ -27,7 +29,6 @@ jobs:
 
             make list-configs
             make build
-
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,8 @@ jobs:
 
             cd cdms
 
-            ls -la ../feedstock/.ci_support/
-
             make list-configs
+            ls -la ../feedstock/.ci_support/
             make build
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
 
             cd cdms/
 
-            make test LOCAL_CONDA_CHANNEL=${WORK_DIR}/local_conda_channel
+            make test LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel
 
             mkdir -p test_results/
             mv tests_html test_results/`make list-config`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ jobs:
         type: executor
     executor: << parameters.os >>
     steps:
+      - checkout:
+          path: cdms
       - run:
           command: |
             pwd
@@ -22,6 +24,9 @@ jobs:
             echo `uname` >> test_os
 
             ls -la .
+
+            cd cdms
+            make list-config
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
           command: |
             export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
             export MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
+            export WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
 
             source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 
@@ -86,7 +87,8 @@ jobs:
 
             cd cdms
 
-            make WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
+            make list-configs
+            make build
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ aliases:
     command: |
       CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
       MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
-      CONDA_PKG_DIR=${CIRCLE_WORKING_DIRECTORY}/conda_pkgs
 
       echo "MINICONDA_DIR ${MINICONDA_DIR}"
 
@@ -23,12 +22,8 @@ aliases:
       source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 
       conda activate base
-      conda config --system --remove-key pkgs_dirs || true
-      conda config --system --append pkgs_dirs ${CONDA_PKG_DIR}
       
       conda info
-
-      ls -la ${CONDA_PKG_DIR}
 
 executors:
   linux:
@@ -49,7 +44,13 @@ jobs:
           at: .
       - checkout:
           path: cdms
+      - restore_cache:
+          key: conda-{{ arch }}
       - run: *setup_miniconda
+      - save_cache:
+          key: conda-{{ arch }}
+          paths:
+            - miniconda
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
+            - condarc
             - cdms
             - miniconda
             - feedstock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
             cp -rf ${WORK_DIR}/build_artifacts ${WORK_DIR}/local_conda_channel
             source ${WORK_DIR}/miniconda/etc/profile.d/conda.sh
             conda activate base
+            conda install -c conda-forge conda-build --yes
             conda index ${WORK_DIR}/local_conda_channel
 
             cd cdms/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,11 @@
 version: 2.1
 
 aliases:
-  - &setup_miniconda
-    name: setup_miniconda
-    command: |
+  - &setup_env
+    name: setup_env
+    command: | 
       export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
       export MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
-
-      echo "MINICONDA_DIR ${MINICONDA_DIR}"
-
-      if [[ `uname` == "Darwin" ]]
-      then
-        curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-      else
-        curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-      fi
-
-      chmod +x miniconda.sh
-      ./miniconda.sh -b -u -p ${MINICONDA_DIR}
-
-      source ${MINICONDA_DIR}/etc/profile.d/conda.sh
-
-      conda activate base
-      
-      conda info
-
-  - &build
-    name: build
-    command: |
-      source ${MINICONDA_DIR}/etc/profile.d/conda.sh
-
-      conda activate base
-
-      conda info
 
 executors:
   linux:
@@ -55,7 +28,26 @@ jobs:
           path: cdms
       - restore_cache:
           key: conda-{{ arch }}
-      - run: *setup_miniconda
+      - run: *setup_env
+      - run:
+          command: |
+            echo "MINICONDA_DIR ${MINICONDA_DIR}"
+
+            if [[ `uname` == "Darwin" ]]
+            then
+              curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+            else
+              curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+            fi
+
+            chmod +x miniconda.sh
+            ./miniconda.sh -b -u -p ${MINICONDA_DIR}
+
+            source ${MINICONDA_DIR}/etc/profile.d/conda.sh
+
+            conda activate base
+            
+            conda info
       - save_cache:
           key: conda-{{ arch }}
           paths:
@@ -73,7 +65,14 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: *build
+      - run: *setup_env
+      - run:
+          command: |
+            source ${MINICONDA_DIR}/etc/profile.d/conda.sh
+
+            conda activate base
+
+            conda info
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,44 +21,49 @@ jobs:
           path: cdms
       - run:
           command: |
-            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
-            export WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
+            export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
 
             cd cdms/
 
             make build
 
-            rm -rf ${WORK_DIR}/miniconda/envs/build
+            mkdir -p build_artificats
+
+            cp conda-bld/**/*.tar.bz2 build_artifacts/
       - persist_to_workspace:
           root: .
           paths:
             - cdms
             - miniconda
-            - feedstock
+            - pkgs
             - conda-bld
+            - build_artifacts
   test:
     parameters:
       os:
         type: executor
     executor: << parameters.os >>
+    environment:
+      OS: << parameters.os >>
     steps:
       - attach_workspace:
           at: .
       - run:
           command: |
-            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
-            export WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
+            export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
 
             cd cdms/
 
             make test
 
-            rm -rf ${WORK_DIR}/miniconda/envs/test
+            mkdir -p test_artifacts/`make list-config`
+
+            cp -rf  tests_html/* test_artifacts/`make list-config`
       - persist_to_workspace:
           root: .
           paths:
-            - miniconda
-            - conda-bld
+            - build_artifacts
+            - test_artifacts
 
   upload:
     machine:
@@ -66,8 +71,8 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: ls -la miniconda/envs/build/conda-bld/linux-64
-      - run: ls -la miniconda/envs/build/conda-bld/osx-64
+      - run: ls -la build_artifacts/
+      - run: ls -la test_artifacts/
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             cd cdms/
 
             make test
-      - persist_to_workspace
+      - persist_to_workspace:
           root: .
           paths:
             - miniconda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
           key: conda-{{ arch }}-1
       - run:
           command: |
-            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIR}`
-            export MINICONDA_DIR=${CIRCLE_WORKING_DIR}/miniconda
+            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+            export MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
 
             echo "MINICONDA_DIR ${MINICONDA_DIR}"
 
@@ -75,8 +75,8 @@ jobs:
           at: .
       - run:
           command: |
-            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIR}`
-            export MINICONDA_DIR=${CIRCLE_WORKING_DIR}/miniconda
+            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+            export MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
 
             source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,5 @@
 version: 2.1
 
-aliases:
-  - &setup_env
-    name: setup_env
-    command: | 
-      echo "export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`" >> ${BASH_ENV}
-      echo "export MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda" >> ${BASH_ENV}
-
 executors:
   linux:
     machine:
@@ -21,75 +14,34 @@ jobs:
       os:
         type: executor
     executor: << parameters.os >>
+    environment:
+      OS: << parameters.os >>
     steps:
-      - attach_workspace:
-          at: .
-      - checkout:
-          path: cdms
-      - restore_cache:
-          key: conda-{{ arch }}-1
       - run:
           command: |
-            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
-            export MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
+            pwd
 
-            echo "MINICONDA_DIR ${MINICONDA_DIR}"
+            echo "${OS}" >> test_os
 
-            if [[ `uname` == "Darwin" ]]
-            then
-              curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-            else
-              curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-            fi
+            ls -la .
 
-            chmod +x miniconda.sh
-            ./miniconda.sh -b -u -p ${MINICONDA_DIR}
-
-            source ${MINICONDA_DIR}/etc/profile.d/conda.sh
-
-            conda activate base
-
-            conda config --system --remove-key pkgs_dirs || true
-            conda config --system --append pkgs_dirs ${CIRCLE_WORKING_DIRECTORY}/conda_pkgs
-            
-            conda info
-
-            conda update -n base conda
-      - save_cache:
-          key: conda-{{ arch }}-1
-          paths:
-            - conda_pkgs
-      - persist_to_workspace:
-          root: .
-          paths:
-            - conda_pkgs
-            - miniconda
-            - cdms
   build:
     parameters:
       os:
         type: executor
     executor: << parameters.os >>
+    environment:
+      OS: << parameters.os >>
     steps:
-      - attach_workspace:
-          at: .
       - run:
           command: |
-            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
-            export MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
-            export WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
+            pwd
 
-            source ${MINICONDA_DIR}/etc/profile.d/conda.sh
+            echo "${OS}" >> test_os
 
-            conda activate base
+            ls -la .
 
-            conda info
-
-            cd cdms
-
-            make list-configs
-            ls -la ../feedstock/.ci_support/
-            make build
+            cat test_os
 
 workflows:
   cdms:
@@ -99,10 +51,10 @@ workflows:
             parameters:
               os: [ linux, macos ]
           name: prep-host-<< matrix.os >>
-      - build:
+      - prep_host:
           matrix:
             parameters:
               os: [ linux, macos ]
-          name: build-<< matrix.os >>
+          name: prep-host-<< matrix.os >>
           requires:
             - prep-host-<< matrix.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ aliases:
   - &setup_env
     name: setup_env
     command: | 
-      export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
-      export MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
+      echo "export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`" >> ${BASH_ENV}
+      echo "export MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda" >> ${BASH_ENV}
 
 executors:
   linux:
@@ -31,6 +31,8 @@ jobs:
       - run: *setup_env
       - run:
           command: |
+            source ${BASE_ENV}
+
             echo "MINICONDA_DIR ${MINICONDA_DIR}"
 
             if [[ `uname` == "Darwin" ]]
@@ -65,9 +67,10 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: *setup_env
       - run:
           command: |
+            source ${BASH_ENV}
+
             source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 
             conda activate base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ aliases:
         curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
       fi
 
+      ls -la .
+
       chmod +x miniconda.sh
 
       ./miniconda.sh -b -p ${MINICONDA_DIR}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,10 @@ jobs:
 
             cd cdms/
 
-            make upload CONDA_TOKEN=${CONDA_TEST_TOKEN} CONDA_USER=${CONDA_USER} \
-              CONDA_UPLOAD_ARGS="--force --label nightly"
+            make upload CONDA_TOKEN=${CONDA_TEST_TOKEN} \
+              CONDA_USER=${CONDA_USER} \
+              CONDA_UPLOAD_ARGS="--force --label nightly" \
+              LOCAL_CHANNEL_DIR=${WORK_DIR}/build_artifacts
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,21 @@ aliases:
       fi
 
       chmod +x miniconda.sh
-      ./miniconda.sh -b -p ${MINICONDA_DIR}
+      ./miniconda.sh -b -u -p ${MINICONDA_DIR}
 
       source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 
       conda activate base
       
+      conda info
+
+  - &build
+    name: build
+    command: |
+      source ${MINICONDA_DIR}/etc/profile.d/conda.sh
+
+      conda activate base
+
       conda info
 
 executors:
@@ -56,6 +65,15 @@ jobs:
           paths:
             - miniconda
             - cdms
+  build:
+    parameters:
+      os:
+        type: executor
+    executor: << parameters.os >>
+    steps:
+      - attach_workspace:
+          at: .
+      - run: *build
 
 workflows:
   cdms:
@@ -64,4 +82,9 @@ workflows:
           matrix:
             parameters:
               os: [ linux, macos ]
-          name: os-<< matrix.os >>
+          name: prep-host--<< matrix.os >>
+      - build:
+          matrix:
+            parameters:
+              os [ linux, macos ]
+          name: build-<< matrix.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,6 @@ jobs:
       - run: date +%Y%m > date
       - restore_cache:
           key: conda-pkgs-{{ arch }}-{{ checksum "date" }}
-      - restore_cache:
-          key: test-data
       - checkout:
           path: cdms
       - run:
@@ -95,13 +93,11 @@ jobs:
               CONDA_TEST_PACKAGES="python=<< parameters.py >>" \
               TEST_OUTPUT_DIR="${WORK_DIR}/test_results" 
 
+            ls -la "${WORK_DIR}/sample_data"
+
       - store_artifacts:
           path: test_results/
           destination: test_results/
-      - save_cache:
-          paths:
-            - sample_data
-          key: test-data
       - save_cache:
           paths:
             - miniconda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ aliases:
   - &setup_miniconda
     name: setup_miniconda
     command: |
+      MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
+
       if [[ `uname` == "Darwin" ]]
       then
         curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
@@ -35,8 +37,6 @@ jobs:
       os:
         type: executor
     executor: << parameters.os >>
-    environment:
-      MINICONDA_DIR: ${CIRCLE_WORKING_DIRECTORY}/miniconda
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
             if [[ ! -e "${WORK_DIR}/test_data" ]]
             then
               mkdir -p "${WORK_DIR}/test_data"
+              mkdir -p "${WORK_DIR}/envs/test/share/cdat/sample_data"
             fi
 
             ln -sf "${WORK_DIR}/test_data" "${WORK_DIR}/envs/test/share/cdat/sample_data"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,22 +15,35 @@ jobs:
         type: executor
     executor: << parameters.os >>
     steps:
+      - attach_workspace:
+          at: .
       - checkout:
           path: cdms
       - run:
           command: |
-            pwd
+            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+            export CONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
 
-            echo `uname` >> test_os
+            if [[ `uname` == "Darwin" ]]
+            then
+              curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+            else
+              curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+            fi
 
-            ls -la .
+            chmod +x miniconda.sh
+            ./miniconda.sh -b -u -p ${CONDA_DIR}
 
-            cd cdms
-            make list-configs SHELL="sh -x"
+            . $(CONDA_DIR)/etc/profile.d/conda.sh
+
+            conda activate base
+
+            conda info
+
       - persist_to_workspace:
           root: .
           paths:
-            - "."
+            - cdms
 
   build:
     parameters:
@@ -40,13 +53,12 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run:
-          command: |
-            pwd
-            
-            ls -la .
-
-            cat test_os
+      - checkout:
+          path: cdms
+      - persist_to_workspace:
+          root: .
+          paths:
+            - cdms
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ aliases:
   - &setup_miniconda
     name: setup_miniconda
     command: |
-      CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
-      MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
+      export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+      export MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
 
       echo "MINICONDA_DIR ${MINICONDA_DIR}"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,11 @@ jobs:
           path: cdms
       - run:
           command: |
-            [[ `uname` == "Darwin" ]] && ARCH=osx-64 || ARCH=linux-64
+            [[ `uname` == "Darwin" ]] && CONDA_ARCH=osx-64 || CONDA_ARCH=linux-64
+            [[ `uname` == "Darwin" ]] && ARCH=osx_64 || ARCH=linux_64
 
             export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
-            export ARTIFACT_DIR=${WORK_DIR}/build_artifacts/${ARCH}
+            export ARTIFACT_DIR=${WORK_DIR}/build_artifacts/${CONDA_ARCH}
 
             pushd cdms/
             make build PATTERN="${ARCH}.*version9.*python<< parameters.py >>"
@@ -34,7 +35,7 @@ jobs:
 
             mkdir -p ${ARTIFACT_DIR}
 
-            cp ${WORK_DIR}/conda-bld/${ARCH}/*.tar.bz2 ${ARTIFACT_DIR}
+            cp ${WORK_DIR}/conda-bld/${CONDA_ARCH}/*.tar.bz2 ${ARTIFACT_DIR}
       - run: date +%Y%m > date
       - persist_to_workspace:
           root: .
@@ -62,6 +63,8 @@ jobs:
           path: cdms
       - run:
           command: |
+            [[ `uname` == "Darwin" ]] && ARCH=osx_64 || ARCH=linux_64
+
             export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
 
             cp -rf ${WORK_DIR}/build_artifacts ${WORK_DIR}/local_conda_channel
@@ -75,7 +78,8 @@ jobs:
             make test LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel
 
             mkdir -p test_results/
-            mv tests_html test_results/`make list-config`
+            VARIANT=`make list-config PATTERN="${ARCH}.*version9.*python<< parameters.py >>"`
+            mv tests_html test_results/${VARIANT}
       - store_artifacts:
           path: test_results/
           destination: test_results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,3 +62,5 @@ workflows:
             parameters:
               os: [ linux, macos ]
           name: test-<<matrix.os>>
+          requires:
+            - build-<< matrix.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
             make build
 
-            rm -rf ${WORKDIR}/miniconda/envs/build
+            rm -rf ${WORK_DIR}/miniconda/envs/build
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,8 @@ jobs:
             export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
             export WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
 
+            cd cdms/
+
             make list-configs
             make build 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,21 +15,19 @@ aliases:
         curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
       fi
 
-      ls -la .
-
       chmod +x miniconda.sh
 
       ./miniconda.sh -b -p ${MINICONDA_DIR}
 
-      ls -la .
-
-      ls -la ${MINICONDA_DIR}
-
       source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 
       conda activate base
-
+      
+      conda config --system --set pkgs_dir ${CIRCLE_WORKING_DIRECTORY}/conda_pkgs
+      
       conda info
+
+      ls -la ${CIRCLE_WORKING_DIRECTORY}/conda_pkgs
 
 executors:
   linux:
@@ -51,6 +49,8 @@ jobs:
       - checkout:
           path: cdms
       - run: *setup_miniconda
+      - persist_to_workspace
+          root: .
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,14 +89,14 @@ jobs:
           at: .
       - checkout:
           path: cdms
-      - run: |
-        command:
-          export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+      - run:
+          command: |
+            export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
 
-          cd cdms/
+            cd cdms/
 
-          make upload CONDA_TOKEN=${CONDA_TEST_TOKEN} CONDA_USER=${CONDA_USER} \
-            CONDA_UPLOAD_ARGS="--force --label nightly"
+            make upload CONDA_TOKEN=${CONDA_TEST_TOKEN} CONDA_USER=${CONDA_USER} \
+              CONDA_UPLOAD_ARGS="--force --label nightly"
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
 
             make test \
               LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel \
-              CONDA_TEST_PACKAGES="<< parameters.libnetcdf >>" \
+              CONDA_TEST_PACKAGES="libnetcdf=*=*<< parameters.libnetcdf >>*" \
               TEST_OUTPUT_DIR="${WORK_DIR}/test_results" 
 
             ls -la "${WORK_DIR}/sample_data"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,10 @@ jobs:
       - run:
           command: |
             export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+            export CONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
             export WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
+
+            . ${CONDA_DIR}/etc/profile.d/conda.sh
 
             cd cdms/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,9 @@ jobs:
 
             cd cdms/
 
-            make test LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel
+            make test \
+              LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel \
+              CONDA_TEST_PACKAGES="python=<< parameters.py >>"
 
             mkdir -p test_results/
             VARIANT=`make list-config PATTERN="${ARCH}.*version9.*python<< parameters.py >>"`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             chmod +x miniconda.sh
             ./miniconda.sh -b -u -p ${CONDA_DIR}
 
-            . $(CONDA_DIR)/etc/profile.d/conda.sh
+            . ${CONDA_DIR}/etc/profile.d/conda.sh
 
             conda activate base
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ aliases:
         curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
       fi
 
+      chmod +x miniconda.sh
+
       ./miniconda.sh -b -p ${CIRCLE_WORKING_DIRECTORY}/miniconda
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ jobs:
             export CONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
             export WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
 
-            . ${CONDA_DIR}/etc/profile.d/conda.sh
-
             cd cdms/
 
             make list-configs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,8 @@ jobs:
             conda install -c conda-forge conda-build --yes
             conda index ${WORK_DIR}/local_conda_channel
 
+            cd cdms/
+
             make create-conda-env \
               ENV=test \
               CHANNELS="-c conda-forge" \
@@ -86,8 +88,6 @@ jobs:
             fi
 
             ln -sf "${WORK_DIR}/test_data" "${WORK_DIR}/envs/test/share/cdat/sample_data"
-
-            cd cdms/
 
             make test \
               LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,22 @@ jobs:
           root: .
           paths:
             - cdms
+  test:
+    parameters:
+      os:
+        type: executor
+    executor: << parameters.os >>
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          command: |
+            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+            export WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
+
+            cd cdms/
+
+            make test
 
 workflows:
   cdms:
@@ -41,3 +57,8 @@ workflows:
             parameters:
               os: [ linux, macos ]
           name: build-<< matrix.os >>
+      - test:
+          matrix:
+            parameters:
+              os: [ linux, macos ]
+          name: test-<<matrix.os>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
             echo `uname` >> test_os
 
             ls -la .
+      - persist_to_workspace:
+          root: .
+          paths:
+            - "."
 
   build:
     parameters:
@@ -29,6 +33,8 @@ jobs:
         type: executor
     executor: << parameters.os >>
     steps:
+      - attach_workspace:
+          at: .
       - run:
           command: |
             pwd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,14 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - checkout:
-          path: cdms
+      - run:
+          command: |
+            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+            export WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
+
+            make list-configs
+            make build 
+
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,5 +86,5 @@ workflows:
       - build:
           matrix:
             parameters:
-              os [ linux, macos ]
+              os: [ linux, macos ]
           name: build-<< matrix.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
     parameters:
       os:
         type: executor
+      py:
+        type: string
     executor: << parameters.os >>
     steps:
       - attach_workspace:
@@ -27,7 +29,7 @@ jobs:
             export ARTIFACT_DIR=${WORK_DIR}/build_artifacts/${ARCH}
 
             pushd cdms/
-            make build
+            make build PATTERN="${ARCH}.*version9.*python<< parameters.py >>"
             popd
 
             mkdir -p ${ARTIFACT_DIR}
@@ -110,6 +112,7 @@ workflows:
           matrix:
             parameters:
               os: [ linux, macos ]
+              py: [ "3.6", "3.7", "3.8" ]
           name: build-<< matrix.os >>
       - test:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,3 +150,6 @@ workflows:
           name: upload
           requires:
             - test
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,18 @@
 version: 2.1
 
+aliases:
+  - &setup_miniconda
+    name: setup_miniconda
+    command: |
+      if [[ `uname` == "Darwin" ]]
+      then
+        curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+      else
+        curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+      fi
+
+      ./miniconda.sh -b -p ${CIRCLE_WORKING_DIRECTORY}/miniconda
+
 executors:
   linux:
     machine:
@@ -18,6 +31,7 @@ jobs:
       - attach_workspace:
           at: .
       - checkout
+      - run: *setup_miniconda
       - run:
           command: |
             echo ${PWD}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,6 @@ jobs:
 
             ln -sf "${WORK_DIR}/sample_data" "${WORK_DIR}/envs/test/share/cdat"
 
-            mkdir -p "{WORK_DIR}/test_results"
-
             make test \
               LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel \
               CONDA_TEST_PACKAGES="libnetcdf=*=*<< parameters.libnetcdf >>*" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,15 @@ jobs:
           command: |
             export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
 
-            cd cdms/
+            pushd cdms
 
             make build
 
-            mkdir -p build_artificats
+            popd
 
-            cp conda-bld/**/*.tar.bz2 build_artifacts/
+            mkdir -p build_artificats/
+
+            cp ${WORK_DIR}/conda-bld/**/*.tar.bz2 ${WORK_DIR}/build_artifacts/
       - persist_to_workspace:
           root: .
           paths:
@@ -54,9 +56,9 @@ jobs:
 
             make test
 
-            mkdir -p test_artifacts/`make list-config`
+            mkdir -p ${WORK_DIR}/test_artifacts/`make list-config`
 
-            cp -rf  tests_html/* test_artifacts/`make list-config`
+            cp -rf  tests_html/* ${WORK_DIR}/test_artifacts/`make list-config`
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,28 +21,28 @@ jobs:
           path: cdms
       - run:
           command: |
+            [[ `uname` == "Darwin" ]] && ARCH=osx-64 || ARCH=linux-64
+
             export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+            export ARTIFACT_DIR=${WORK_DIR}/build_artifacts/${ARCH}
 
-            pushd cdms
-
+            pushd cdms/
             make build
-
             popd
 
-            mkdir -p ${WORK_DIR}/build_artifacts/
+            mkdir -p ${ARTIFACT_DIR}
 
-            cp ${WORK_DIR}/conda-bld/**/*.tar.bz2 ${WORK_DIR}/build_artifacts/
+            cp ${WORK_DIR}/conda-bld/${ARCH}/*.tar.bz2 ${ARTIFACT_DIR}
+      - run: date +%Y%m > date
       - persist_to_workspace:
           root: .
           paths:
-            - cdms
-            - conda-bld
-            - miniconda
             - build_artifacts
       - save_cache:
           paths:
+            - miniconda
             - pkgs
-          key: conda-pkgs-{{ arch }}
+          key: conda-pkgs-{{ arch }}-{{ checksum "date" }}
   test:
     parameters:
       os:
@@ -51,8 +51,11 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - run: date +%Y%m > date
       - restore_cache:
-          key: conda-pkgs-{{ arch }} 
+          key: conda-pkgs-{{ arch }}-{{ checksum "date" }}
+      - checkout:
+          path: cdms
       - run:
           command: |
             export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
@@ -61,24 +64,16 @@ jobs:
 
             make test
 
-            export TEST_ARTIFACTS=${WORK_DIR}/test_artifacts/`make list-config`
-            
-            mkdir -p ${TEST_ARTIFACTS}
-
-            cp -rf tests_html/* ${TEST_ARTIFACTS}
-
-            # Prevent errors when merging workspaces for upload
-            rm -rf ${WORK_DIR}/cdms
-            rm -rf ${WORK_DIR}/conda-bld
-            rm -rf ${WORK_DIR}/miniconda
-      - persist_to_workspace:
-          root: .
-          paths:
-            - test_artifacts
+            mkdir -p test_results/
+            mv tests_html test_results/`make list-config`
+      - store_artifacts:
+          path: test_results/
+          destination: test_results/
       - save_cache:
           paths:
+            - miniconda
             - pkgs
-          key: conda-pkgs-{{ arch }}
+          key: conda-pkgs-{{ arch }}-{{ checksum "date" }}
 
   upload:
     machine:
@@ -87,7 +82,6 @@ jobs:
       - attach_workspace:
           at: .
       - run: ls -la build_artifacts/
-      - run: ls -la test_artifacts/
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,9 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - run: date +%Y%m > date
+      - restore_cache:
+          key: conda-pkgs-{{ arch }}-{{ checksum "date" }}
       - checkout:
           path: cdms
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ jobs:
           root: .
           paths:
             - cdms
+            - miniconda
+            - feedstock
   test:
     parameters:
       os:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
             - cdms
             - miniconda
             - feedstock
+            - conda-bld
   test:
     parameters:
       os:
@@ -57,6 +58,7 @@ jobs:
           root: .
           paths:
             - miniconda
+            - conda-bld
 
   upload:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
   - &setup_miniconda
     name: setup_miniconda
     command: |
-      MINICONDA_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}/miniconda`
+      MINICONDA_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`/miniconda
 
       echo "MINICONDA_DIR ${MINICONDA_DIR}"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,14 @@ jobs:
           command: |
             export WORK_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`
 
+            cp -ef ${WORK_DIR}/build_artifacts ${WORK_DIR}/local_conda_channel
+            source ${WORK_DIR}/miniconda/etc/profile.d/conda.sh
+            conda activate base
+            conda index ${WORK_DIR}/local_conda_channel
+
             cd cdms/
 
-            make test
+            make test LOCAL_CONDA_CHANNEL=${WORK_DIR}/local_conda_channel
 
             mkdir -p test_results/
             mv tests_html test_results/`make list-config`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,9 +82,11 @@ workflows:
           matrix:
             parameters:
               os: [ linux, macos ]
-          name: prep-host--<< matrix.os >>
+          name: prep-host-<< matrix.os >>
       - build:
           matrix:
             parameters:
               os: [ linux, macos ]
           name: build-<< matrix.os >>
+          requires:
+            - prep-host-<< matrix.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ aliases:
       source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 
       conda activate base
-      conda config --system --remove-key pkgs_dirs
+      conda config --system --remove-key pkgs_dirs || exit 0
       conda config --system --append pkgs_dirs ${CONDA_PKG_DIR}
       
       conda info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ aliases:
 
       conda activate base
       
-      conda config --system --set pkgs_dir ${CIRCLE_WORKING_DIRECTORY}/conda_pkgs
+      conda config --system --set pkgs_dirs ${CIRCLE_WORKING_DIRECTORY}/conda_pkgs
       
       conda info
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,8 @@ jobs:
       - run: date +%Y%m > date
       - restore_cache:
           key: conda-pkgs-{{ arch }}-{{ checksum "date" }}
+      - restore_cache:
+          key: test-data
       - checkout:
           path: cdms
       - run:
@@ -73,6 +75,18 @@ jobs:
             conda install -c conda-forge conda-build --yes
             conda index ${WORK_DIR}/local_conda_channel
 
+            make create-conda-env \
+              ENV=test \
+              CHANNELS="-c conda-forge" \
+              PACKAGES='python=3.8'
+
+            if [[ ! -e "${WORK_DIR}/test_data" ]]
+            then
+              mkdir -p "${WORK_DIR}/test_data"
+            fi
+
+            ln -sf "${WORK_DIR}/test_data" "${WORK_DIR}/envs/test/share/cdat/sample_data"
+
             cd cdms/
 
             make test \
@@ -85,6 +99,10 @@ jobs:
       - store_artifacts:
           path: test_results/
           destination: test_results/
+      - save_cache:
+          paths:
+            - test_data
+          key: test-data
       - save_cache:
           paths:
             - miniconda
@@ -108,8 +126,8 @@ jobs:
 
             cd cdms/
 
-            make upload CONDA_TOKEN=${CONDA_TEST_TOKEN} \
-              CONDA_USER=${CONDA_USER} \
+            make upload CONDA_TOKEN=${CONDA_UPLOAD_TOKEN} \
+              CONDA_USER=cdat \
               CONDA_UPLOAD_ARGS="--force --label nightly" \
               LOCAL_CHANNEL_DIR=${WORK_DIR}/build_artifacts
 
@@ -134,3 +152,6 @@ workflows:
           name: upload
           requires:
             - test
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
       - run:
           command: |
             export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
-            export CONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
             export WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
 
             cd cdms/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - checkout:
           path: cdms
       - run: *setup_miniconda
-      - persist_to_workspace
+      - persist_to_workspace:
           root: .
           paths:
             - miniconda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,8 @@ jobs:
 
             ln -sf "${WORK_DIR}/sample_data" "${WORK_DIR}/envs/test/share/cdat"
 
+            mkdir -p "{WORK_DIR}/test_results"
+
             make test \
               LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel \
               CONDA_TEST_PACKAGES="libnetcdf=*=*<< parameters.libnetcdf >>*" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,27 +82,27 @@ jobs:
               CHANNELS="-c conda-forge" \
               PACKAGES='python=3.8'
 
-            if [[ ! -e "${WORK_DIR}/test_data" ]]
+            if [[ ! -e "${WORK_DIR}/sample_data" ]]
             then
-              mkdir -p "${WORK_DIR}/test_data"
-              mkdir -p "${WORK_DIR}/envs/test/share/cdat/sample_data"
+              mkdir -p "${WORK_DIR}/sample_data"
+              mkdir -p "${WORK_DIR}/envs/test/share/cdat"
             fi
 
-            ln -sf "${WORK_DIR}/test_data" "${WORK_DIR}/envs/test/share/cdat/sample_data"
+            ln -sf "${WORK_DIR}/sample_data" "${WORK_DIR}/envs/test/share/cdat"
 
             make test \
               LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel \
               CONDA_TEST_PACKAGES="python=<< parameters.py >>"
 
-            mkdir -p test_results/
+            mkdir -p "${WORK_DIR}/test_results/"
             VARIANT=`make list-configs PATTERN="${ARCH}.*version9.*python<< parameters.py >>"`
-            mv tests_html test_results/${VARIANT}
+            mv "${WORK_DIR}/cdms/tests_html" "${WORK_DIR}/test_results/${VARIANT}"
       - store_artifacts:
           path: test_results/
           destination: test_results/
       - save_cache:
           paths:
-            - test_data
+            - sample_data
           key: test-data
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,10 @@ jobs:
 
             conda info
 
+            cd cdms
+
+            make WORK_DIR=${CIRCLE_WORKING_DIRECTORY}
+
 workflows:
   cdms:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,9 @@ aliases:
   - &setup_miniconda
     name: setup_miniconda
     command: |
-      MINICONDA_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}`/miniconda
+      CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
+      MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
+      CONDA_PKG_DIR=${CIRCLE_WORKING_DIRECTORY}/conda_pkgs
 
       echo "MINICONDA_DIR ${MINICONDA_DIR}"
 
@@ -16,18 +18,17 @@ aliases:
       fi
 
       chmod +x miniconda.sh
-
       ./miniconda.sh -b -p ${MINICONDA_DIR}
 
       source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 
       conda activate base
-      
-      conda config --system --set pkgs_dirs ${CIRCLE_WORKING_DIRECTORY}/conda_pkgs
+      conda config --system --remove-key pkgs_dirs
+      conda config --system --append pkgs_dirs ${CONDA_PKG_DIR}
       
       conda info
 
-      ls -la ${CIRCLE_WORKING_DIRECTORY}/conda_pkgs
+      ls -la ${CONDA_PKG_DIR}
 
 executors:
   linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ aliases:
 
       ./miniconda.sh -b -p ${MINICONDA_DIR}
 
+      ls -la ${MINICODNA_DIR}
+
       source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 
       conda activate base
@@ -43,10 +45,6 @@ jobs:
       - checkout:
           path: cdms
       - run: *setup_miniconda
-      - run:
-          command: |
-            echo ${PWD}
-            ls -la .
 
 workflows:
   cdms:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ jobs:
       - checkout:
           path: cdms
       - restore_cache:
-          key: conda-{{ arch }}
-      - run: *setup_env
+          key: conda-{{ arch }}-1
       - run:
           command: |
-            source ${BASH_ENV}
+            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIR}`
+            export MINICONDA_DIR=${CIRCLE_WORKING_DIR}/miniconda
 
             echo "MINICONDA_DIR ${MINICONDA_DIR}"
 
@@ -48,15 +48,21 @@ jobs:
             source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 
             conda activate base
+
+            conda config --system --remove-key pkgs_dirs || true
+            conda config --system --append pkgs_dirs ${CIRCLE_WORKING_DIRECTORY}/conda_pkgs
             
             conda info
+
+            conda update -n base conda
       - save_cache:
-          key: conda-{{ arch }}
+          key: conda-{{ arch }}-1
           paths:
-            - miniconda
+            - conda_pkgs
       - persist_to_workspace:
           root: .
           paths:
+            - conda_pkgs
             - miniconda
             - cdms
   build:
@@ -69,7 +75,8 @@ jobs:
           at: .
       - run:
           command: |
-            source ${BASH_ENV}
+            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIR}`
+            export MINICONDA_DIR=${CIRCLE_WORKING_DIR}/miniconda
 
             source ${MINICONDA_DIR}/etc/profile.d/conda.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             ls -la .
 
             cd cdms
-            make list-config
+            make list-configs
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,14 +14,12 @@ jobs:
       os:
         type: executor
     executor: << parameters.os >>
-    environment:
-      OS: << parameters.os >>
     steps:
       - run:
           command: |
             pwd
 
-            echo "${OS}" >> test_os
+            echo `uname` >> test_os
 
             ls -la .
 
@@ -30,14 +28,12 @@ jobs:
       os:
         type: executor
     executor: << parameters.os >>
-    environment:
-      OS: << parameters.os >>
     steps:
       - run:
           command: |
             pwd
 
-            echo "${OS}" >> test_os
+            echo `uname` >> test_os
 
             ls -la .
 
@@ -51,10 +47,10 @@ workflows:
             parameters:
               os: [ linux, macos ]
           name: prep-host-<< matrix.os >>
-      - prep_host:
+      - build:
           matrix:
             parameters:
               os: [ linux, macos ]
-          name: prep-host-<< matrix.os >>
+          name: build-<< matrix.os >>
           requires:
             - prep-host-<< matrix.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run: *setup_env
       - run:
           command: |
-            source ${BASE_ENV}
+            source ${BASH_ENV}
 
             echo "MINICONDA_DIR ${MINICONDA_DIR}"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,19 @@ jobs:
             cd cdms/
 
             make test
+      - persist_to_workspace
+          root: .
+          paths:
+            - miniconda
+
+  upload:
+    machine:
+      image: circleci/classic:latest
+    steps:
+      - attach_workspace:
+          at: .
+      - run: ls -la miniconda/envs/build/conda-bld/linux-64
+      - run: ls -la miniconda/envs/build/conda-bld/osx-64
 
 workflows:
   cdms:
@@ -67,3 +80,7 @@ workflows:
           name: test-<<matrix.os>>
           requires:
             - build-<< matrix.os >>
+      - upload:
+          name: upload
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
               CONDA_TEST_PACKAGES="python=<< parameters.py >>"
 
             mkdir -p test_results/
-            VARIANT=`make list-config PATTERN="${ARCH}.*version9.*python<< parameters.py >>"`
+            VARIANT=`make list-configs PATTERN="${ARCH}.*version9.*python<< parameters.py >>"`
             mv tests_html test_results/${VARIANT}
       - store_artifacts:
           path: test_results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             ls -la .
 
             cd cdms
-            make list-configs
+            make list-configs SHELL="sh -x"
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,6 @@ jobs:
       os:
         type: executor
     executor: << parameters.os >>
-    environment:
-      OS: << parameters.os >>
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             make create-conda-env \
               ENV=test \
               CHANNELS="-c conda-forge" \
-              PACKAGES='python=3.8'
+              PACKAGES="python=<< parameters.py >>"
 
             if [[ ! -e "${WORK_DIR}/sample_data" ]]
             then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,171 +1,25 @@
 version: 2.1
 
-aliases:
-  - &setup_env
-    name: setup_env
-    command: |
-       if [[ `uname` == "Darwin" ]]; then
-          export PROJECT_DIR=/Users/distiller/project/workdir/macos
-       else
-          export PROJECT_DIR=/home/circleci/project/workdir/linux
-       fi
-       echo "export WORKDIR=$PROJECT_DIR/$PY_VER" >> $BASH_ENV
-       cat $BASH_ENV
-       source $BASH_ENV
-       mkdir -p $WORKDIR
-
-  - &setup_miniconda
-    name: setup_miniconda
-    command: |
-       source $BASH_ENV
-       git clone https://github.com/CDAT/cdat.git $WORKDIR/cdat
-       # install_miniconda.py installs miniconda3 under $WORKDIR/miniconda
-       python $WORKDIR/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3'
-
-
-  - &conda_rerender
-    name: conda_rerender
-    command: |
-       source $BASH_ENV
-       source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate base
-       make conda-rerender workdir=$WORKDIR conda_build_env=base branch=$CIRCLE_BRANCH
-
-  - &conda_build
-    name: conda_build
-    command: |
-       source $BASH_ENV
-       source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate base
-       os=`uname`
-       artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
-       make conda-build workdir=$WORKDIR conda_build_env=base artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER
-
-  - &setup_run_tests
-    name: setup_run_tests
-    command: |
-       source $BASH_ENV
-       source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate base
-       export CONDA_PY_VER="python=$PY_VER"
-       export LIBNETCDF_VER="libnetcdf=*=${LIBNETCDF}_*"
-
-       echo "make setup-tests conda=$WORKDIR/miniconda/bin/conda extra_pkgs=\"$CONDA_PY_VER $LIBNETCDF_VER $COVERAGE_PKGS\""
-       make setup-tests extra_pkgs="$CONDA_PY_VER $LIBNETCDF_VER $COVERAGE_PKGS"
-
-       make conda-dump-env artifact_dir=$PWD/spec_artifacts conda_env_filename=$CIRCLE_JOB
-
-  - &run_tests
-    name: run_tests
-    command: |
-       source $BASH_ENV
-       source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       make run-tests workdir=$WORKDIR
-    no_output_timeout: 10m
-
-  - &conda_upload
-    name: conda_upload
-    command: |
-       source $BASH_ENV
-       source $WORKDIR/miniconda/etc/profile.d/conda.sh
-       conda activate base
-       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN"
-       make conda-upload workdir=$WORKDIR $UPLOAD_OPTIONS artifact_dir="$PWD/artifacts/*/"
-
-executors:
-   linux:
-      machine:
-         image: circleci/classic:latest
-   macos:
-      macos:
-         xcode: "11.4.0"
-
 jobs:
-   build:
-      parameters:
-         os:
-            type: executor
-         py_ver: 
-            type: string
-      executor: << parameters.os >>
-      environment:
-         PY_VER: << parameters.py_ver >>
-      steps:
-         - checkout
-         - attach_workspace:
-              at: .
-         - run: *setup_env
-         - run: *setup_miniconda
-         - run: *conda_rerender
-         - run: *conda_build
-         - persist_to_workspace:
-              root: .
-              paths:
-                 - workdir
-                 - artifacts
-
-   test:
-      parameters:
-         os:
-            type: executor
-         py_ver: 
-            type: string
-         libnetcdf: 
-            type: string
-      executor: << parameters.os >>
-      environment:
-         PY_VER: << parameters.py_ver >>
-         LIBNETCDF: << parameters.libnetcdf >>
-      steps:
-         - checkout
-         - attach_workspace:
-              at: .
-         - run: echo "LIBNETCDF=$LIBNETCDF" >> $BASH_ENV
-         - run: *setup_env
-         - run: *setup_run_tests
-         - run: *run_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
-         - store_artifacts:
-              path: spec_artifacts
-              destination: spec_artifacts
-
-   upload:
-      machine:
-         image: circleci/classic:latest
-      environment:
-         PY_VER: "3.7"
-      steps:
-         - checkout
-         - attach_workspace:
-              at: .
-         - run: *setup_env
-         - run: *conda_upload
+  prep_host:
+    parameters:
+      os:
+        type: executor
+    executor: << parameters.os >>
+    steps:
+      - attach_workspace:
+          at: .
+      - checkout
+      - run:
+          command: |
+            echo ${PWD}
+            ls -la .
 
 workflows:
-   cdms:
-      jobs:
-         - build:
-              matrix:
-                 parameters:
-                    os: [ linux, macos ]
-                    py_ver: [ "3.6", "3.7", "3.8" ]
-              name: build-<< matrix.os >>-<< matrix.py_ver >>
-
-         - test:
-              matrix:
-                 parameters:
-                    os: [ linux, macos ]
-                    py_ver: [ "3.6", "3.7", "3.8" ]
-                    libnetcdf: [ "nompi", "mpi_mpich", "mpi_openmpi" ]
-              name: test-<< matrix.os >>-<< matrix.py_ver >>-<< matrix.libnetcdf >>
-              requires:
-                 - build-<< matrix.os >>-<< matrix.py_ver >>
-
-         - upload:
-              requires:
-                 - test
-              filters:
-                 branches:
-                    only: master
+  cdms:
+    jobs:
+      - prep_host:
+          matrix:
+            parameters:
+              os: [ linux, macos ]
+          name: os-<< matrix.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,7 @@ jobs:
       - run:
           command: |
             pwd
-
-            echo `uname` >> test_os
-
+            
             ls -la .
 
             cat test_os

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,9 @@ aliases:
   - &setup_miniconda
     name: setup_miniconda
     command: |
-      MINICONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
+      MINICONDA_DIR=`pwd ${CIRCLE_WORKING_DIRECTORY}/miniconda`
+
+      echo "MINICONDA_DIR ${MINICONDA_DIR}"
 
       if [[ `uname` == "Darwin" ]]
       then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,8 @@ jobs:
     parameters:
       os:
         type: executor
+      py:
+        type: string
     executor: << parameters.os >>
     steps:
       - attach_workspace:
@@ -113,14 +115,15 @@ workflows:
             parameters:
               os: [ linux, macos ]
               py: [ "3.6", "3.7", "3.8" ]
-          name: build-<< matrix.os >>
+          name: build-<< matrix.os >>-<< matrix.py >>
       - test:
           matrix:
             parameters:
               os: [ linux, macos ]
-          name: test-<<matrix.os>>
+              py: [ "3.6", "3.7", "3.8" ]
+          name: test-<<matrix.os>>-<< matrix.py >>
           requires:
-            - build-<< matrix.os >>
+            - build-<< matrix.os >>-<< matrix.py >>
       - upload:
           name: upload
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,12 @@ jobs:
 
             cd cdms/
 
-            make list-configs
             make build
+
+            rm -rf ${WORKDIR}/miniconda/envs/build
       - persist_to_workspace:
           root: .
           paths:
-            - condarc
             - cdms
             - miniconda
             - feedstock
@@ -51,6 +51,8 @@ jobs:
             cd cdms/
 
             make test
+
+            rm -rf ${WORK_DIR}/miniconda/envs/test
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
 
             popd
 
-            mkdir -p build_artificats/
+            mkdir -p build_artifacts/
 
             cp ${WORK_DIR}/conda-bld/**/*.tar.bz2 ${WORK_DIR}/build_artifacts/
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,11 +92,9 @@ jobs:
 
             make test \
               LOCAL_CHANNEL_DIR=${WORK_DIR}/local_conda_channel \
-              CONDA_TEST_PACKAGES="python=<< parameters.py >>"
+              CONDA_TEST_PACKAGES="python=<< parameters.py >>" \
+              TEST_OUTPUT_DIR="${WORK_DIR}/test_results" 
 
-            mkdir -p "${WORK_DIR}/test_results/"
-            VARIANT=`make list-configs PATTERN="${ARCH}.*version9.*python<< parameters.py >>"`
-            mv "${WORK_DIR}/cdms/tests_html" "${WORK_DIR}/test_results/${VARIANT}"
       - store_artifacts:
           path: test_results/
           destination: test_results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
           root: .
           paths:
             - cdms
+            - miniconda
 
   build:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,43 +9,6 @@ executors:
       xcode: "11.4.0"
 
 jobs:
-  prep_host:
-    parameters:
-      os:
-        type: executor
-    executor: << parameters.os >>
-    steps:
-      - attach_workspace:
-          at: .
-      - checkout:
-          path: cdms
-      - run:
-          command: |
-            export CIRCLE_WORKING_DIRECTORY=`pwd ${CIRCLE_WORKING_DIRECTORY}`
-            export CONDA_DIR=${CIRCLE_WORKING_DIRECTORY}/miniconda
-
-            if [[ `uname` == "Darwin" ]]
-            then
-              curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-            else
-              curl -L -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-            fi
-
-            chmod +x miniconda.sh
-            ./miniconda.sh -b -u -p ${CONDA_DIR}
-
-            . ${CONDA_DIR}/etc/profile.d/conda.sh
-
-            conda activate base
-
-            conda info
-
-      - persist_to_workspace:
-          root: .
-          paths:
-            - cdms
-            - miniconda
-
   build:
     parameters:
       os:
@@ -65,7 +28,7 @@ jobs:
             cd cdms/
 
             make list-configs
-            make build 
+            make build
 
       - persist_to_workspace:
           root: .
@@ -75,11 +38,6 @@ jobs:
 workflows:
   cdms:
     jobs:
-      - prep_host:
-          matrix:
-            parameters:
-              os: [ linux, macos ]
-          name: prep-host-<< matrix.os >>
       - build:
           matrix:
             parameters:

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 #     Files that git should ignore...
 #****************************************************************
 
+.workdir
 .tempdir
 TAGS
 *~

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test:
 		$(CONDA_RC); \
 		conda config --set channel_priority strict; \
 		conda create -n test --yes -c file://$(LOCAL_CHANNEL_DIR) -c conda-forge -c cdat/label/nightly \
-		cdms2 testsrunner cdat_info pytest 'python=<< parameters.py >>' pip; \
+		cdms2 testsrunner cdat_info pytest pip $(CONDA_TEST_PACKAGES); \
 		conda activate test; \
 		conda info; \
 		python run_tests.py -H -v2 -n 1

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ test: create-conda-env
 		conda install --yes $(CHANNELS) cdms2 testsrunner cdat_info pytest pip \
 		$(CONDA_TEST_PACKAGES); \
 		conda info; \
+		conda list --explicit > $(TEST_OUTPUT_DIR)/environment.txt; \
 		python run_tests.py -H -v2 -n 1
 
 	ls $(CI_SUPPORT_DIR)/*.yaml | \

--- a/Makefile
+++ b/Makefile
@@ -90,4 +90,5 @@ test:
 
 	$(CONDA_SETUP); \
 		$(CONDA_ACTIVATE) test; \
-		python run_tests.py --html
+		# CircleCI linux doesn't play nice with activating environments, loads the system python
+		$(CONDA_DIR)/envs/test/bin/python run_tests.py --html

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ prep-feedstock:
 
 .PHONY: list-configs
 list-configs: prep-feedstock
-	$(call LIST_CONFIGS,".*")
+	$(foreach item,$(call FIND_VARIANT),echo $(item);)
 
 .PHONY: build
 build: CONDA_ENV := build

--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,4 @@ build: export UPLOAD_PACKAGES := False
 build: export CONFIG := $(CONFIG)
 build: export EXTRA_CB_OPTIONS := --croot $(WORK_DIR)/conda-bld
 build: prep-conda prep-feedstock
-	$(CONDA) info; \
-		$(FEEDSTOCK_DIR)/.scripts/build_steps.sh
+	$(FEEDSTOCK_DIR)/.scripts/build_steps.sh

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CI_SUPPORT_DIR := $(FEEDSTOCK_DIR)/.ci_support
 SCRIPTS_DIR := $(FEEDSTOCK_DIR)/.scripts
 
 CONDARC_PATH := $(WORK_DIR)/condarc
-CONDA_ACTIVATE = source $(shell conda info --base)/bin/activate $(1)
+CONDA_ACTIVATE = . $(shell conda info --base)/bin/activate $(1)
 CONDA = $(call CONDA_ACTIVATE,$(CONDA_ENV)); CONDARC=$(CONDARC_PATH) conda
 
 ifeq (Darwin,$(shell uname))
@@ -23,9 +23,10 @@ endif
 prep-conda: CONDA_ENV := base
 prep-conda:
 	echo "conda-build:\n  root-dir: $(WORK_DIR)/conda-bld\n\n" > $(CONDARC_PATH)
+
 	$(CONDA) config --set always_yes true
 
-	# $(CONDA) create -n build conda-build anaconda-client
+	$(CONDA) create -n build conda-build anaconda-client
 
 .PHONY: prep-feedstock
 prep-feedstock:

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,24 @@ build: install-conda prep-feedstock create-conda-env
 				 EXTRA_CB_OPTIONS='--croot $(LOCAL_CHANNEL_DIR)' \
 				 $(SCRIPTS_DIR)/build_steps.sh | tee $(WORK_DIR)/`cat $(PWD)/.variant`
 
+.PHONY: build-docs
+build-docs: ENV := docs
+build-docs: CHANNELS := -c file://$(LOCAL_CHANNEL_DIR) -c conda-forge
+build-docs: PACKAGES := cdms2 mock pillow sphinx recommonmark \
+	numpydoc
+build-docs: create-conda-env
+	$(CONDA_ENV); \
+		$(CONDA_ACTIVATE) docs; \
+		$(CONDA_RC); \
+		conda info; \
+		cd docs/source; \
+		sphinx-build -T -E -d _build/doctrees-readthedocs -D \
+		language=en . _build/html
+
+.PHONY: clean-docs
+clean-docs:
+	rm -rf $(ENVS_DIR)/docs
+
 .PHONY: test
 test: ENV := test
 test: CHANNELS := -c file://$(LOCAL_CHANNEL_DIR) -c conda-forge -c cdat/label/nightly

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ LOCAL_CHANNEL_DIR := $(if $(LOCAL_CHANNEL_DIR),$(LOCAL_CHANNEL_DIR),$(WORK_DIR)/
 FEEDSTOCK_DIR := $(WORK_DIR)/feedstock
 SCRIPTS_DIR := $(FEEDSTOCK_DIR)/.scripts
 CI_SUPPORT_DIR := $(FEEDSTOCK_DIR)/.ci_support
+TEST_OUTPUT_DIR := $(if $(TEST_OUTPUT_DIR),$(TEST_OUTPUT_DIR),$(PWD))
 
 CONDARC := $(WORK_DIR)/condarc
 CONDA_HOOKS = eval "$$($(CONDA_DIR)/bin/conda 'shell.bash' 'hook')"
@@ -109,6 +110,13 @@ test: create-conda-env
 		conda install --yes $(CHANNELS) cdms2 testsrunner cdat_info pytest pip; \
 		conda info; \
 		python run_tests.py -H -v2 -n 1
+
+	ls $(CI_SUPPORT_DIR)/*.yaml | \
+		grep -e '$(if $(PATTERN),$(PATTERN),$(VPATTERN))' | \
+		awk '{ n=split($$1,a,"/");sub(/\.yaml$//,"",a[n]);print a[n] }' \
+		> $(PWD)/.variant
+
+	cp -rf $(PWD)/tests_html $(TEST_OUTPUT_DIR)/`cat $(PWD)/.variant`
 
 .PHONY: upload
 upload: ENV := upload

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ ifeq ($(wildcard $(CONDA_DIR)/envs/build),)
 		conda create -n build --yes python=3.8
 endif
 
-	ls $(CI_SUPPORT_DIR)/*.yaml | grep -E $(if $(PATTERN),$(PATTERN),$(VPATTERN)) \
+	ls $(CI_SUPPORT_DIR)/*.yaml | grep -E "$(if $(PATTERN),$(PATTERN),$(VPATTERN))" \
 		| awk '{ n=split($$1,a,"/");sub(/\.yaml$//,"",a[n]);print a[n] }' \
 		> $(PWD)/.variant
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ list-configs: prep-feedstock
 	$(call FIND_VARIANT)
 
 .PHONY: build
-build: CONDA_ENV := build
+build: export CONDA_ENV := build
 build: export FEEDSTOCK_ROOT=$(FEEDSTOCK_DIR)
 build: export RECIPE_ROOT=$(RECIPE_DIR)
 build: export CONDARC := $(WORK_DIR)/condarc

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test:
 	# Force conda to install cdms from local channel
 	$(CONDA) config --set channel_priority strict
 
-	$(CONDA) create -n test \
+	$(CONDA) create -n test -y \
 		-c file://$(CONDA_CHANNEL) -c conda-forge -c cdat/label/nightly \
 		cdms2 testsrunner cdat_info pytest 'python=3.8' pip
 

--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,4 @@ build: export UPLOAD_PACKAGES := False
 build: export CONFIG := $(CONFIG)
 build: prep-conda prep-feedstock
 	$(CONDA) info; \
-		$(SHELL) -c "$(FEEDSTOCK_DIR)/.scripts/build_steps.sh"
+		$(FEEDSTOCK_DIR)/.scripts/build_steps.sh

--- a/Makefile
+++ b/Makefile
@@ -67,17 +67,23 @@ list-configs:
 		grep -e '$(if $(PATTERN),$(PATTERN),$(VPATTERN))' | \
 		awk '{ n=split($$1,a,"/");sub(/\.yaml$//,"",a[n]);print a[n] }'
 
+.PHONY: debug
+debug:
+	@echo $(ENVS_DIR)/build
+	@echo $(wildcard $(ENVS_DIR)/build)
+
 .PHONY: build
 build: install-conda prep-feedstock
-ifeq ($(wildcard $(CONDA_DIR)/envs/build),)
+ifeq ($(wildcard $(ENVS_DIR)/build),)
 	$(CONDA_ENV); \
 		$(CONDA_ACTIVATE) base; \
 		$(CONDA_RC); \
 		conda create -n build --yes python=3.8
 endif
 
-	ls $(CI_SUPPORT_DIR)/*.yaml | grep -E "$(if $(PATTERN),$(PATTERN),$(VPATTERN))" \
-		| awk '{ n=split($$1,a,"/");sub(/\.yaml$//,"",a[n]);print a[n] }' \
+	ls $(CI_SUPPORT_DIR)/*.yaml | \
+		grep -e '$(if $(PATTERN),$(PATTERN),$(VPATTERN))' | \
+		awk '{ n=split($$1,a,"/");sub(/\.yaml$//,"",a[n]);print a[n] }' \
 		> $(PWD)/.variant
 
 	CONFIG=`cat $(PWD)/.variant` \
@@ -104,7 +110,7 @@ test:
 
 .PHONY: upload
 upload:
-ifeq ($(wildcard $(CONDA_DIR)/envs/upload),)
+ifeq ($(wildcard $(ENVS_DIR)/upload),)
 	$(CONDA_ENV); \
 		$(CONDA_ACTIVATE) base; \
 		$(CONDA_RC); \

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,14 @@ SCRIPTS_DIR := $(FEEDSTOCK_DIR)/.scripts
 CI_SUPPORT_DIR := $(FEEDSTOCK_DIR)/.ci_support
 
 CONDA_CHANNEL := $(CONDA_DIR)/envs/build/conda-bld
-CONDA_ACTIVATE := $(CONDA_DIR)/bin/activate
-CONDA = . $(CONDA_ACTIVATE) $(CONDA_ENV); CONDARC=$(WORK_DIR)/condarc $(CONDA_DIR)/bin/conda
+CONDA_SH := . $(CONDA_DIR)/etc/profile.d/conda.sh
+CONDA_ACTIVATE := . $(CONDA_DIR)/bin/activate
+CONDA_SETUP = $(CONDA_SH); \
+							$(CONDA_ACTIVATE) $(CONDA_ENV); \
+							$(CONDA_ACTIVATE) $(CONDA_ENV)
+CONDA = $(CONDA_SETUP); \
+				export CONDARC=$(WORK_DIR)/condarc; \
+				$(CONDA_DIR)/bin/conda
 
 .PHONY: install-conda
 install-conda:
@@ -82,5 +88,6 @@ test:
 		-c file://$(CONDA_CHANNEL) -c conda-forge -c cdat/label/nightly \
 		cdms2 testsrunner cdat_info pytest 'python=3.8' pip
 
-	. $(CONDA_ACTIVATE) test; \
+	$(CONDA_SETUP); \
+		$(CONDA_ACTIVATE) test; \
 		python run_tests.py --html

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ FEEDSTOCK_DIR := $(WORK_DIR)/feedstock
 SCRIPTS_DIR := $(FEEDSTOCK_DIR)/.scripts
 CI_SUPPORT_DIR := $(FEEDSTOCK_DIR)/.ci_support
 
-CONDA_CHANNEL := $(CONDA_DIR)/envs/build/conda-bld
+CONDA_CHANNEL := $(WORK_DIR)/conda-bld
 CONDA_ACTIVATE := source $(CONDA_DIR)/etc/profile.d/conda.sh; \
 	source $(CONDA_DIR)/bin/activate; source $(CONDA_DIR)/bin/activate
 CONDA = export CONDARC=$(WORK_DIR)/condarc; \
@@ -77,6 +77,7 @@ endif
 				 RECIPE_ROOT=$(FEEDSTOCK_DIR)/recipe \
 				 UPLOAD_PACKAGES=False \
 				 CONDARC=$(WORK_DIR)/condarc \
+				 EXTRA_CB_OPTIONS='--croot $(WORK_DIR)/conda-bld' \
 				 $(SCRIPTS_DIR)/build_steps.sh | tee $(WORK_DIR)/`cat $(PWD)/.variant`
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,5 @@ test:
 		-c file://$(CONDA_CHANNEL) -c conda-forge -c cdat/label/nightly \
 		cdms2 testsrunner cdat_info pytest 'python=3.8' pip
 
-	$(CONDA_ACTIVATE) test
-
-	python run_tests.py --html
+	$(CONDA_ACTIVATE) test; \
+		python run_tests.py --html

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ clean-docs:
 .PHONY: test
 test: ENV := test
 test: CHANNELS := -c file://$(LOCAL_CHANNEL_DIR) -c conda-forge -c cdat/label/nightly
-test: create-conda-env
+test: prep-feedstock create-conda-env
 	$(CONDA_ENV); \
 		$(CONDA_ACTIVATE) base; \
 		$(CONDA_RC); \

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ build: export CONDARC := $(WORK_DIR)/condarc
 build: export FEEDSTOCK_NAME := cdms2
 build: export UPLOAD_PACKAGES := False
 build: export CONFIG := $(CONFIG)
-build: export EXTRA_CB_OPTIONS := --croot $(WORK_DIR)/conda-b
+build: export EXTRA_CB_OPTIONS := --croot $(WORK_DIR)/conda-bld
 build: prep-conda prep-feedstock
 	$(CONDA) info; \
 		$(FEEDSTOCK_DIR)/.scripts/build_steps.sh

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 install-conda:
 	$(if $(wildcard $(WORK_DIR)/miniconda.sh),,curl -L -o $(WORK_DIR)/miniconda.sh $(CONDA_SCRIPT_URL); \
 		chmod +x $(WORK_DIR)/miniconda.sh)
-	$(if $(wildcard $(CONDA_DIR)),,./miniconda.sh -b -p $(CONDA_DIR))
+	$(if $(wildcard $(CONDA_DIR)),,./miniconda.sh -b -p $(WORK_DIR)/miniconda.sh)
 
 .PHONY: prep-conda
 prep-conda: CONDA_ENV := base

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .DEFAULT_GOAL := build
 
 MKTEMP = $(if $(wildcard $(1)),$(shell cat $(1)),$(shell mktemp -d >> $(1); cat $(1)))
-FIND_VARIANT = $(notdir $(basename $(wildcard $(FEEDSTOCK_DIR)/.ci_support/*$(1)*.yaml)))
+define FIND_VARIANT
+	python -c "import os,re;x=[y.replace('.yaml','') for y in os.listdir('$(CI_SUPPORT_DIR)') if re.match('$(1)',y) is not None];print('\n'.join(sorted(x)))"
+endef
 
 WORK_DIR := $(if $(WORK_DIR),$(WORK_DIR),$(call MKTEMP,$(PWD)/.workdir))
 FEEDSTOCK_DIR := $(WORK_DIR)/feedstock
@@ -13,17 +15,15 @@ CONDARC_PATH := $(WORK_DIR)/condarc
 CONDA_ACTIVATE = . $(shell conda info --base)/bin/activate $(1)
 CONDA = $(call CONDA_ACTIVATE,$(CONDA_ENV)); CONDARC=$(CONDARC_PATH) conda
 
-ifeq (Darwin,$(shell uname))
-CONFIG := $(call FIND_VARIANT,osx*version9*python3.8)
+ifeq (Darwin, $(shell uname))
+CONFIG = $(shell $(call FIND_VARIANT,osx.*version9.*python3.8.*yaml))
 else
-CONFIG := $(call FIND_VARIANT,linux*version8*python3.8)
+CONFIG = $(shell $(call FIND_VARIANT,linux.*version9.*python3.8.*yaml))
 endif
 
 .PHONY: prep-conda
 prep-conda: CONDA_ENV := base
 prep-conda:
-	echo "conda-build:\n  root-dir: $(WORK_DIR)/conda-bld\n\n" > $(CONDARC_PATH)
-
 	$(CONDA) config --set always_yes true
 
 	$(CONDA) create -n build conda-build anaconda-client
@@ -34,11 +34,11 @@ prep-feedstock:
 
 	python build_files/fix_conda_recipe.py $(RECIPE_DIR)/meta.yaml $(PWD)
 
-	cd $(SCRIPTS_DIR); patch -N < $(PWD)/build_files/build_steps.patch || true
+	cd $(SCRIPTS_DIR); patch --forward < $(PWD)/build_files/build_steps.patch || true
 
 .PHONY: list-configs
 list-configs: prep-feedstock
-	$(foreach item,$(call FIND_VARIANT),echo $(item);)
+	$(call FIND_VARIANT)
 
 .PHONY: build
 build: CONDA_ENV := build
@@ -48,6 +48,7 @@ build: export CONDARC := $(WORK_DIR)/condarc
 build: export FEEDSTOCK_NAME := cdms2
 build: export UPLOAD_PACKAGES := False
 build: export CONFIG := $(CONFIG)
+build: export EXTRA_CB_OPTIONS := --croot $(WORK_DIR)/conda-b
 build: prep-conda prep-feedstock
 	$(CONDA) info; \
 		$(FEEDSTOCK_DIR)/.scripts/build_steps.sh

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ CONDA = $(call CONDA_ACTIVATE,$(CONDA_ENV)); CONDARC=$(CONDARC_PATH) conda
 
 ifeq (Darwin, $(shell uname))
 VARIANT_PATTERN := $(if $(VARIANT_PATTERN),$(VARIANT_PATTERN),osx.*version9.*python3.8.*yaml)
-CONFIG = $(shell $(call FIND_VARIANT,$(VARIANT_PATTERN)))
+CONFIG = $(call FIND_VARIANT,$(VARIANT_PATTERN))
 CONDA_SCRIPT_URL = https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 else
 VARIANT_PATTERN := $(if $(VARIANT_PATTERN),$(VARIANT_PATTERN),linux.*version9.*python3.8.*yaml)
-CONFIG = $(shell $(call FIND_VARIANT,$(VARIANT_PATTERN)))
+CONFIG = $(call FIND_VARIANT,$(VARIANT_PATTERN))
 CONDA_SCRIPT_URL = https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 endif
 
@@ -30,7 +30,7 @@ endif
 install-conda:
 	$(if $(wildcard $(WORK_DIR)/miniconda.sh),,curl -L -o $(WORK_DIR)/miniconda.sh $(CONDA_SCRIPT_URL); \
 		chmod +x $(WORK_DIR)/miniconda.sh)
-	$(if $(wildcard $(CONDA_DIR)),,$(WORK_DIR)/miniconda.sh -b -p $(WORK_DIR)/miniconda.sh)
+	$(if $(wildcard $(CONDA_DIR)),,$(WORK_DIR)/miniconda.sh -b -p $(CONDA_DIR))
 
 .PHONY: prep-conda
 prep-conda: CONDA_ENV := base

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CONDA_CHANNEL := $(CONDA_DIR)/envs/build/conda-bld
 CONDA_SH := . $(CONDA_DIR)/etc/profile.d/conda.sh
 CONDA_ACTIVATE := . $(CONDA_DIR)/bin/activate
 CONDA_SETUP = $(CONDA_SH); \
-							$(CONDA_ACTIVATE) $(CONDA_ENV); \
+							$(CONDA_ACTIVATE); \
 							$(CONDA_ACTIVATE) $(CONDA_ENV)
 CONDA = $(CONDA_SETUP); \
 				export CONDARC=$(WORK_DIR)/condarc; \
@@ -91,4 +91,4 @@ test:
 	$(CONDA_SETUP); \
 		$(CONDA_ACTIVATE) test; \
 		# CircleCI linux doesn't play nice with activating environments, loads the system python
-		$(CONDA_DIR)/envs/test/bin/python run_tests.py --html
+		python run_tests.py --html

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MKTEMP = $(if $(wildcard $(1)),$(shell cat $(1)),$(shell mktemp -d > $(1); cat $
 ifeq (Darwin,$(shell uname))
 VPATTERN = osx.*version9.*python3.8
 else
-VPATTERN = linux.*version8.*python3.8
+VPATTERN = linux.*version9.*python3.8
 endif
 
 SRC_DIR := $(if $(SRC_DIR),$(SRC_DIR),$(PWD))
@@ -33,6 +33,8 @@ endif
 ifeq ($(wildcard $(CONDA_DIR)),)
 	$(SHELL) $(MINICONDA_PATH) -b -p $(CONDA_DIR)
 endif
+
+	$(CONDA) config --set always_yes true
 
 .PHONY: prep-feedstock
 prep-feedstock:

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ ifeq ($(wildcard $(CONDA_DIR)/envs/build),)
 		conda create -n build --yes python=3.8
 endif
 
-	ls $(CI_SUPPORT_DIR)/*.yaml | grep -E $(VPATTERN) \
+	ls $(CI_SUPPORT_DIR)/*.yaml | grep -E $(if $(PATTERN),$(PATTERN),$(VPATTERN)) \
 		| awk '{ n=split($$1,a,"/");sub(/\.yaml$//,"",a[n]);print a[n] }' \
 		> $(PWD)/.variant
 

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test:
 		$(CONDA_RC); \
 		conda config --set channel_priority strict; \
 		conda create -n test --yes -c file://$(LOCAL_CHANNEL_DIR) -c conda-forge -c cdat/label/nightly \
-		cdms2 testsrunner cdat_info pytest 'python=3.8' pip; \
+		cdms2 testsrunner cdat_info pytest 'python=<< parameters.py >>' pip; \
 		conda activate test; \
 		conda info; \
 		python run_tests.py -H -v2 -n 1

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ endif
 .PHONY: test
 test: CONDA_ENV := base
 test:
+	# Force conda to install cdms from local channel
+	$(CONDA) config --set channel_priority strict
+
 	$(CONDA) create -n test \
 		-c file://$(CONDA_CHANNEL) -c conda-forge -c cdat/label/nightly \
 		cdms2 testsrunner cdat_info pytest 'python=3.8' pip

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 install-conda:
 	$(if $(wildcard $(WORK_DIR)/miniconda.sh),,curl -L -o $(WORK_DIR)/miniconda.sh $(CONDA_SCRIPT_URL); \
 		chmod +x $(WORK_DIR)/miniconda.sh)
-	$(if $(wildcard $(CONDA_DIR)),,./miniconda.sh -b -p $(WORK_DIR)/miniconda.sh)
+	$(if $(wildcard $(CONDA_DIR)),,$(WORK_DIR)/miniconda.sh -b -p $(WORK_DIR)/miniconda.sh)
 
 .PHONY: prep-conda
 prep-conda: CONDA_ENV := base

--- a/Makefile
+++ b/Makefile
@@ -1,172 +1,52 @@
-.PHONY: conda-info conda-list setup-build setup-tests conda-rerender \
-	conda-build conda-upload conda-dump-env run-tests run-coveralls \
-	setup-feedstock rerender-feedstock build
+.DEFAULT_GOAL := build
 
-SHELL = /bin/bash
+MKTEMP = $(if $(wildcard $(1)),$(shell cat $(1)),$(shell mktemp -d >> $(1); cat $(1)))
+FIND_VARIANT = $(notdir $(basename $(wildcard $(FEEDSTOCK_DIR)/.ci_support/*$(1)*.yaml)))
 
-os = $(shell uname)
-pkg_name = cdms2
-repo_name = cdms
+WORK_DIR := $(if $(WORK_DIR),$(WORK_DIR),$(call MKTEMP,$(PWD)/.workdir))
+FEEDSTOCK_DIR := $(WORK_DIR)/feedstock
+RECIPE_DIR := $(FEEDSTOCK_DIR)/recipe
+CI_SUPPORT_DIR := $(FEEDSTOCK_DIR)/.ci_support
+SCRIPTS_DIR := $(FEEDSTOCK_DIR)/.scripts
 
-user ?= cdat
-label ?= nightly
+CONDARC_PATH := $(WORK_DIR)/condarc
+CONDA_ACTIVATE = source $(shell conda info --base)/bin/activate $(1)
+CONDA = $(call CONDA_ACTIVATE,$(CONDA_ENV)); CONDARC=$(CONDARC_PATH) conda
 
-build_script = conda-recipes/build_tools/conda_build.py
-
-test_pkgs = testsrunner pytest 
-last_stable ?= 3.1.5
-
-conda_build_env ?= build-$(pkg_name)
-conda_test_env ?= test-$(pkg_name)
-branch ?= $(shell git rev-parse --abbrev-ref HEAD)
-extra_channels ?= cdat/label/nightly conda-forge
-artifact_dir ?= $(PWD)/artifacts
-conda_env_filename ?= spec-file
-build_version ?= 3.7
-
-ifneq ($(coverage),)
-coverage = -c tests/coverage.json --coverage-from-egg
-endif
-
-conda_recipes_branch ?= master
-
-ifeq ($(workdir),)
-ifeq ($(wildcard $(PWD)/.tempdir),)
-workdir := $(shell mktemp -d "/tmp/build-$(pkg_name).XXXXXXXX")
-$(shell echo $(workdir) > $(PWD)/.tempdir)
-endif
-
-workdir := $(shell cat $(PWD)/.tempdir)
-endif
-
-conda ?= $(or $(CONDA_EXE),$(shell find /opt/*conda*/bin $(HOME)/*conda*/bin -type f -iname conda))
-conda_bin := $(patsubst %/conda,%,$(conda))
-conda_act := $(conda_bin)/activate
-conda_act_cmd := source $(conda_act)
-conda_rc := $(workdir)/condarc
-conda_cmd := CONDARC=$(conda_rc) conda
-feedstock := $(workdir)/cdms2-feedstock
-
-conda_build_extra = --copy_conda_package $(artifact_dir)
-
-setup-feedstock:
-	$(conda) config --file $(conda_rc) --add channels defaults
-	$(conda) config --file $(conda_rc) --add channels conda-forge
-	$(conda) config --file $(conda_rc) --set always_yes true
-
-	git clone https://github.com/conda-forge/cdms2-feedstock $(feedstock) || exit 0
-
-	$(conda_act_cmd) base; \
-		$(conda_cmd) create -n $(conda_build_env) -c conda-forge conda-build conda-smithy sed
-
-	# Replace source section, uses local path pointed to repo to capture changes.
-	$(conda_act_cmd) $(conda_build_env); \
-		sed -i'' -e "/source:/{N; :loop; N; s/build://; Tloop;{ s/.*/source:\n  path: $(subst /,\/,$(PWD))\n\nbuild:/ }}" \
-		$(feedstock)/recipe/meta.yaml
-
-rerender-feedstock:
-	$(conda_act_cmd) $(conda_build_env); \
-		$(conda_cmd) smithy rerender --feedstock_directory $(feedstock)
-
-build: py_variant ?= 3.7
-build: os_variant := $(or $(if $(findstring Darwin,$(os)),osx),linux)
-build: setup-feedstock rerender-feedstock
-	$(conda_act_cmd) $(conda_build_env); \
-		$(conda_cmd) build -m $(feedstock)/.ci_support/$(os_variant)_64_python$(py_variant)*.yaml -c conda-forge $(feedstock)/recipe
-
-build-docs:
-	$(conda_act_cmd) base; \
-		conda env create -n readthedocs-cdms2 -f docs/environment.yaml; \
-		$(conda_act_cmd) readthedocs-cdms2; \
-		conda install -y mock pillow sphinx sphinx_rtd_theme; \
-		python -m pip install -U --no-cache-dir recommonmark readthedocs-sphinx-ext; \
-		python setup.py install --force; \
-		cd docs/source; \
-		sphinx-build -T -E -b readthedocs -d _build/doctrees-readthedocs -D language=en . _build/html
-
-conda-info:
-	$(conda_act_cmd) $(conda_test_env); conda info
-
-conda-list:
-	$(conda_act_cmd) $(conda_test_env); conda list
-
-dev-docker: container := dev-$(pkg_name)
-dev-docker:
-	docker run -d --name $(container) -v  $(PWD):/src -w /src continuumio/miniconda3 /bin/sleep infinity || exit 0
-	docker start $(container)
-	docker exec -it $(container) /bin/bash -c "apt update; apt install -y make"
-	docker exec -it $(container) /bin/bash -c "make dev-environment"
-	docker exec -it $(container) /bin/bash -c "conda init bash; echo 'conda activate $(conda_test_env)' >> ~/.bashrc"
-	docker exec -it $(container) /bin/bash -l
-
-dev-docker-run: container:= dev-$(pkg_name)
-dev-docker-run:
-	docker exec -it $(container) /bin/bash -l
-
-dev-environment: arch := $(if $(findstring $(os),Darwin),osx,linux)
-dev-environment: build_deps := $(shell cat dependencies.txt)
-dev-environment: run_deps := $(shell cat dependencies_run.txt)
-dev-environment: 
-	git clone https://github.com/conda-forge/cdms2-feedstock $(workdir)/cdms2-feedstock || exit 0
-
-	$(conda_act_cmd) base; conda create -y -n $(conda_build_env) \
-		-c conda-forge conda-build
-
-	$(conda_act_cmd) $(conda_build_env); \
-		conda render -c conda-forge -m $(workdir)/cdms2-feedstock/.ci_support/$(arch)_64_python3.7*.yaml $(workdir)/cdms2-feedstock/recipe > dependencies.yaml; \
-		python -c "import yaml;d=open('dependencies.yaml').read();d=d.split('\n');i=d.index('package:');d=d[i:];y=yaml.load('\n'.join(d),Loader=yaml.SafeLoader);print(' '.join([f'\"{x}\"' for x in y['requirements']['build']]))" > dependencies.txt; \
-		python -c "import yaml;d=open('dependencies.yaml').read();d=d.split('\n');i=d.index('package:');d=d[i:];y=yaml.load('\n'.join(d),Loader=yaml.SafeLoader);print(' '.join([f'\"{x}\"' for x in y['requirements']['run']]))" > dependencies_run.txt
-
-	cat dependencies.txt
-		
-	$(conda_act_cmd) base; \
-		conda create -n $(conda_test_env) -y -c conda-forge -c cdat/label/nightly $(build_deps) $(test_pkgs); \
-		$(conda_act_cmd) $(conda_test_env); \
-		conda install -y -c conda-forge -c cdat/label/nightly $(run_deps)
-
-dev-install:
-	$(conda_act_cmd) $(conda_test_env); \
-		python setup.py build --force; \
-		python setup.py install --force --record files.txt
-
-dev-build: conda_build_extra += --local_repo $(PWD)
-dev-build: setup-build conda-rerender conda-build
-
-setup-build:
-ifeq ($(wildcard $(workdir)/conda-recipes),)
-	git clone -b $(conda_recipes_branch) https://github.com/CDAT/conda-recipes $(workdir)/conda-recipes
+ifeq (Darwin,$(shell uname))
+CONFIG := $(call FIND_VARIANT,osx*version9*python3.8)
 else
-	cd $(workdir)/conda-recipes; git pull
+CONFIG := $(call FIND_VARIANT,linux*version8*python3.8)
 endif
 
-setup-tests:
-	$(conda_act_cmd) base; conda create -y -n $(conda_test_env) --use-local \
-		$(foreach x,$(extra_channels),-c $(x)) $(pkg_name) $(foreach x,$(test_pkgs),"$(x)") \
-		$(foreach x,$(extra_pkgs),"$(x)")
+.PHONY: prep-conda
+prep-conda: CONDA_ENV := base
+prep-conda:
+	echo "conda-build:\n  root-dir: $(WORK_DIR)/conda-bld\n\n" > $(CONDARC_PATH)
+	$(CONDA) config --set always_yes true
 
-conda-rerender: setup-build 
-	python $(workdir)/$(build_script) -w $(workdir) -l $(last_stable) -B 0 -p $(pkg_name) -r $(repo_name) \
-		-b $(branch) --do_rerender --conda_env $(conda_build_env) --ignore_conda_missmatch \
-		--conda_activate $(conda_act) $(conda_build_extra)
+	# $(CONDA) create -n build conda-build anaconda-client
 
-conda-build:
-	mkdir -p $(artifact_dir)
+.PHONY: prep-feedstock
+prep-feedstock:
+	$(if $(wildcard $(FEEDSTOCK_DIR)),,git clone https://github.com/conda-forge/cdms2-feedstock $(FEEDSTOCK_DIR))
 
-	python $(workdir)/$(build_script) -w $(workdir) -p $(pkg_name) --build_version $(build_version) \
-		--do_build --conda_env $(conda_build_env) --extra_channels $(extra_channels) \
-		--conda_activate $(conda_act) $(conda_build_extra)
+	python build_files/fix_conda_recipe.py $(RECIPE_DIR)/meta.yaml $(PWD)
 
-conda-upload:
-	$(conda_act_cmd) $(conda_build_env); \
-		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*.tar.bz2
+	cd $(SCRIPTS_DIR); patch -N < $(PWD)/build_files/build_steps.patch || exit 0
 
-conda-dump-env:
-	mkdir -p $(artifact_dir)
+.PHONY: list-configs
+list-configs: prep-feedstock
+	$(call LIST_CONFIGS,".*")
 
-	$(conda_act_cmd) $(conda_test_env); conda list --explicit > $(artifact_dir)/$(conda_env_filename).txt
-
-run-tests:
-	$(conda_act_cmd) $(conda_test_env); python run_tests.py -H -v2 -n 1 
-
-run-coveralls:
-	$(conda_act_cmd) $(conda_test_env); coveralls;
+.PHONY: build
+build: CONDA_ENV := build
+build: export FEEDSTOCK_ROOT=$(FEEDSTOCK_DIR)
+build: export RECIPE_ROOT=$(RECIPE_DIR)
+build: export CONDARC := $(WORK_DIR)/condarc
+build: export FEEDSTOCK_NAME := cdms2
+build: export UPLOAD_PACKAGES := False
+build: export CONFIG := $(CONFIG)
+build: prep-conda prep-feedstock
+	$(CONDA) info; \
+		$(SHELL) -c "$(FEEDSTOCK_DIR)/.scripts/build_steps.sh"

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ prep-feedstock:
 
 	python build_files/fix_conda_recipe.py $(RECIPE_DIR)/meta.yaml $(PWD)
 
-	cd $(SCRIPTS_DIR); patch -N < $(PWD)/build_files/build_steps.patch || exit 0
+	cd $(SCRIPTS_DIR); patch -N < $(PWD)/build_files/build_steps.patch || true
 
 .PHONY: list-configs
 list-configs: prep-feedstock

--- a/Makefile
+++ b/Makefile
@@ -1,66 +1,68 @@
 .DEFAULT_GOAL := build
 
-MKTEMP = $(if $(wildcard $(1)),$(shell cat $(1)),$(shell mktemp -d >> $(1); cat $(1)))
-define FIND_VARIANT
-	python -c "import os,re;x=[y.replace('.yaml','') for y in os.listdir('$(CI_SUPPORT_DIR)') if re.match('$(1)',y) is not None];print('\n'.join(sorted(x)))"
-endef
+MKTEMP = $(if $(wildcard $(1)),$(shell cat $(1)),$(shell mktemp -d > $(1); cat $(1)))
 
-WORK_DIR := $(if $(WORK_DIR),$(WORK_DIR),$(call MKTEMP,$(PWD)/.workdir))
-FEEDSTOCK_DIR := $(WORK_DIR)/feedstock
-RECIPE_DIR := $(FEEDSTOCK_DIR)/recipe
-CI_SUPPORT_DIR := $(FEEDSTOCK_DIR)/.ci_support
-SCRIPTS_DIR := $(FEEDSTOCK_DIR)/.scripts
-
-CONDA_DIR := $(WORK_DIR)/mininconda
-CONDARC_PATH := $(WORK_DIR)/condarc
-CONDA_ACTIVATE = . $(CONDA_DIR)/bin/activate $(1)
-CONDA = $(call CONDA_ACTIVATE,$(CONDA_ENV)); CONDARC=$(CONDARC_PATH) conda
-
-ifeq (Darwin, $(shell uname))
-VARIANT_PATTERN := $(if $(VARIANT_PATTERN),$(VARIANT_PATTERN),osx.*version9.*python3.8.*yaml)
-CONFIG = $(call FIND_VARIANT,$(VARIANT_PATTERN))
-CONDA_SCRIPT_URL = https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+ifeq (Darwin,$(shell uname))
+VPATTERN = osx.*version9.*python3.8
 else
-VARIANT_PATTERN := $(if $(VARIANT_PATTERN),$(VARIANT_PATTERN),linux.*version9.*python3.8.*yaml)
-CONFIG = $(call FIND_VARIANT,$(VARIANT_PATTERN))
-CONDA_SCRIPT_URL = https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+VPATTERN = linux.*version8.*python3.8
 endif
+
+SRC_DIR := $(if $(SRC_DIR),$(SRC_DIR),$(PWD))
+WORK_DIR := $(if $(WORK_DIR),$(WORK_DIR),$(call MKTEMP,$(PWD)/.workdir))
+MINICONDA_PATH := $(WORK_DIR)/miniconda.sh
+CONDA_DIR := $(WORK_DIR)/miniconda
+FEEDSTOCK_DIR := $(WORK_DIR)/feedstock
+SCRIPTS_DIR := $(FEEDSTOCK_DIR)/.scripts
+CI_SUPPORT_DIR := $(FEEDSTOCK_DIR)/.ci_support
+
+CONDA := CONDARC=$(WORK_DIR)/condarc $(CONDA_DIR)/bin/conda
 
 .PHONY: install-conda
 install-conda:
-	$(if $(wildcard $(WORK_DIR)/miniconda.sh),,curl -L -o $(WORK_DIR)/miniconda.sh $(CONDA_SCRIPT_URL); \
-		chmod +x $(WORK_DIR)/miniconda.sh)
-	$(if $(wildcard $(CONDA_DIR)),,$(WORK_DIR)/miniconda.sh -b -p $(CONDA_DIR))
+ifeq ($(wildcard $(MINICONDA_PATH)),)
+ifeq (Darwin,$(shell uname))
+	curl -L -o $(MINICONDA_PATH) https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+else
+	curl -L -o $(MINICONDA_PATH) https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+endif
+else
+	@echo $(MINICONDA_PATH) exists
+endif
 
-.PHONY: prep-conda
-prep-conda: CONDA_ENV := base
-prep-conda: install-conda
-	$(CONDA) config --set always_yes true
-
-	$(CONDA) create -n build conda-build anaconda-client
+ifeq ($(wildcard $(CONDA_DIR)),)
+	$(SHELL) $(MINICONDA_PATH) -b -p $(CONDA_DIR)
+endif
 
 .PHONY: prep-feedstock
-prep-feedstock: prep-conda
-	$(if $(wildcard $(FEEDSTOCK_DIR)),,git clone https://github.com/conda-forge/cdms2-feedstock $(FEEDSTOCK_DIR))
-
-	python build_files/fix_conda_recipe.py $(RECIPE_DIR)/meta.yaml $(PWD)
+prep-feedstock:
+ifeq ($(wildcard $(FEEDSTOCK_DIR)),)
+	git clone https://github.com/conda-forge/cdms2-feedstock $(FEEDSTOCK_DIR)
+endif
 
 	cd $(SCRIPTS_DIR); patch --forward < $(PWD)/build_files/build_steps.patch || true
 
+	python build_files/fix_conda_recipe.py $(FEEDSTOCK_DIR)/recipe/meta.yaml $(SRC_DIR)
+
 .PHONY: list-configs
-list-configs: prep-feedstock
-	$(call FIND_VARIANT)
+list-configs:
+	ls $(CI_SUPPORT_DIR)/*.yaml | awk '{ n=split($$1,a,"/");sub(/\.yaml$//,"",a[n]);print a[n] }'
 
 .PHONY: build
-build: export CONDA_ENV := build
-build: export CONDA_DIR := $(WORK_DIR)/miniconda
-build: export FEEDSTOCK_ROOT=$(FEEDSTOCK_DIR)
-build: export RECIPE_ROOT=$(RECIPE_DIR)
-build: export CONDARC := $(WORK_DIR)/condarc
-build: export FEEDSTOCK_NAME := cdms2
-build: export UPLOAD_PACKAGES := False
-build: export CONFIG := $(CONFIG)
-build: export EXTRA_CB_OPTIONS := --croot $(WORK_DIR)/conda-bld
-build: export PS1 :=
-build: prep-feedstock
-	$(FEEDSTOCK_DIR)/.scripts/build_steps.sh
+build: install-conda prep-feedstock
+ifeq ($(wildcard $(CONDA_DIR)/envs/build),)
+	$(CONDA) create -n build python=3.8
+endif
+
+	ls $(CI_SUPPORT_DIR)/*.yaml | grep -E $(VPATTERN) \
+		| awk '{ n=split($$1,a,"/");sub(/\.yaml$//,"",a[n]);print a[n] }' \
+		> $(PWD)/.variant
+
+	CONFIG=`cat $(PWD)/.variant` \
+				 CONDA_DIR=$(CONDA_DIR) \
+				 CONDA_ENV=build \
+				 FEEDSTOCK_ROOT=$(FEEDSTOCK_DIR) \
+				 RECIPE_ROOT=$(FEEDSTOCK_DIR)/recipe \
+				 UPLOAD_PACKAGES=False \
+				 CONDARC=$(WORK_DIR)/condarc \
+				 $(SCRIPTS_DIR)/build_steps.sh

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ endif
 
 	$(CONDA_ENV); \
 		$(CONDA_ACTIVATE) base; \
-		conda config --file $(CONDARC) --set always_yes true; \
 		$(CONDA_RC); \
 		conda info		
 
@@ -72,7 +71,7 @@ ifeq ($(wildcard $(CONDA_DIR)/envs/build),)
 	$(CONDA_ENV); \
 		$(CONDA_ACTIVATE) base; \
 		$(CONDA_RC); \
-		conda create -n build python=3.8
+		conda create -n build --yes python=3.8
 endif
 
 	ls $(CI_SUPPORT_DIR)/*.yaml | grep -E $(VPATTERN) \
@@ -95,7 +94,7 @@ test:
 		$(CONDA_ACTIVATE) base; \
 		$(CONDA_RC); \
 		conda config --set channel_priority strict; \
-		conda create -n test -c file://$(CONDA_CHANNEL) -c conda-forge -c cdat/label/nightly \
+		conda create -n test --yes -c file://$(CONDA_CHANNEL) -c conda-forge -c cdat/label/nightly \
 		cdms2 testsrunner cdat_info pytest 'python=3.8' pip; \
 		conda activate test; \
 		conda info; \

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,6 @@ build: install-conda prep-feedstock create-conda-env
 
 .PHONY: test
 test: ENV := test
-test: PACAKGES := $(CONDA_TEST_PACKAGES)
 test: CHANNELS := -c file://$(LOCAL_CHANNEL_DIR) -c conda-forge -c cdat/label/nightly
 test: create-conda-env
 	$(CONDA_ENV); \
@@ -107,7 +106,8 @@ test: create-conda-env
 		$(CONDA_RC); \
 		conda config --set channel_priority strict; \
 		conda activate $(ENV); \
-		conda install --yes $(CHANNELS) cdms2 testsrunner cdat_info pytest pip; \
+		conda install --yes $(CHANNELS) cdms2 testsrunner cdat_info pytest pip \
+		$(CONDA_TEST_PACKAGES); \
 		conda info; \
 		python run_tests.py -H -v2 -n 1
 

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,22 @@ test:
 		conda info; \
 		python run_tests.py -H -v2 -n 1
 
+.PHONY: upload
+upload:
+ifeq ($(wildcard $(CONDA_DIR)/envs/upload),)
+	$(CONDA_ENV); \
+		$(CONDA_ACTIVATE) base; \
+		$(CONDA_RC); \
+		conda create -n upload --yes python=3.8 anaconda-client
+endif
+
+	$(CONDA_ENV); \
+		$(CONDA_ACTIVATE) base; \
+		$(CONDA_RC); \
+		conda activate upload; \
+		conda info; \
+		anaconda -t $(CONDA_TOKEN) upload -u $(CONDA_USER) $(CONDA_UPLOAD_ARGS) $(LOCAL_CHANNEL_DIR)/**/*.tar.bz2
+
 .PHONY: clean
 clean:
 ifneq ($(wildcard $(WORK_DIR)),)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ### Install
 ```bash
 conda create -n cdms2 -c conda-forge cdms2
+conda activate cdms2
 ```
 
 ### List build variants

--- a/README.md
+++ b/README.md
@@ -1,55 +1,42 @@
 # CDMS2
 
-### Builds
 [![CircleCI](https://circleci.com/gh/CDAT/cdms.svg?style=svg)](https://circleci.com/gh/CDAT/cdms)
-[![Coverage Status](https://coveralls.io/repos/github/CDAT/cdms/badge.svg)](https://coveralls.io/github/CDAT/cdms)
-![platforms](http://img.shields.io/badge/platforms-linux%20|%20osx-lightgrey.svg)
 
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/cdms2/badges/version.svg)](https://anaconda.org/conda-forge/cdms2)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/cdms2/badges/latest_release_relative_date.svg)](https://anaconda.org/conda-forge/cdms2)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/cdms2/badges/downloads.svg)](https://anaconda.org/conda-forge/cdms2)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/cdms2/badges/platforms.svg)](https://anaconda.org/conda-forge/cdms2)
 
-### Anaconda
-[![Anaconda-Server Badge](https://anaconda.org/uvcdat/cdms2/badges/version.svg)](https://anaconda.org/uvcdat/cdms2)
-[![Anaconda-Server Badge](https://anaconda.org/uvcdat/cdms2/badges/downloads.svg)](https://anaconda.org/uvcdat/cdms2)
-[![Anaconda-Server Badge](https://anaconda.org/uvcdat/cdms2/badges/installer/conda.svg)](https://conda.anaconda.org/uvcdat)
-
-# Development
-
-## Building conda package
-
+### Install
 ```bash
-make dev-build
+conda create -n cdms2 -c conda-forge cdms2
 ```
 
-### Build in docker container
+### List build variants
 ```bash
-make dev-docker
+make list-configs
 ```
 
-## Makefile targets
-
-- **build-docs**: Creates environment and builds docs.
-- **conda-info**: Runs `conda info` in the test environment.
-- **conda-list**: Runs `conda list` in the test environment.
-- **dev-docker**: Builds dev environment in a docker container.
-- **dev-docker-run**: Will run docker container.
-- **dev-environment**: Will create dev environment using local conda.
-- **dev-install**: Builds and installs CDMS2 in dev environment. Run this after making any code changes.
-- **setup-build**: Clones CDAT/conda-recipes into workdir.
-- **setup-tests**: Creates test environment using local conda.
-- **conda-rerender**: Rerenders conda recipe using conda smithy.
-- **conda-build**: Builds conda recipe.
-- **conda-upload**: Uploads conda build artifacts.
-- **conda-dump-env**: Dumps test environment using `conda list --explicit`, this generates a file with the specific files installed.
-- **run-tests**: Runs units tests in test environment.
-- **run-coveralls**: Runs coverage in test environment.
-
-## Bumping version
-
-We're using [bump2version](https://github.com/c4urself/bump2version) to manage versioning.
-
-This will update the following files:
-- setup.py
-- docs/source/conf.py
+### Build package
+This will install miniconda in a temporary directory, clone the conda-forge feedstock and build the package.
 
 ```bash
-bumpversion <major,minor,patch>
+make
+```
+
+### Build a specific variant
+You can specifiy the exact variant name returned by `make list-configs` or using a regex pattern.
+
+```bash
+make PATTERN="osx.*version9.*python3.6"
+```
+
+### Test package
+```bash
+make test
+```
+
+### Clean a build
+```bash
+make clean
 ```

--- a/build_files/build_steps.patch
+++ b/build_files/build_steps.patch
@@ -1,0 +1,41 @@
+--- build_steps.sh	2021-02-09 09:01:08.000000000 -0800
++++ build_steps.sh.new	2021-02-09 09:03:41.000000000 -0800
+@@ -12,24 +12,23 @@
+ export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
+ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+ 
+-cat >~/.condarc <<CONDARC
+-
+-conda-build:
+- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+-
+-CONDARC
++# cat >~/.condarc <<CONDARC
++# 
++# conda-build:
++#  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
++# 
++# CONDARC
+ 
+ conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
+ 
+ # set up the condarc
+ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+ 
+-source run_conda_forge_build_setup
++# source run_conda_forge_build_setup
+ 
+ # make the build number clobber
+ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+ 
+-
+ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+@@ -50,4 +49,4 @@
+     fi
+ fi
+ 
+-touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"
+\ No newline at end of file
++# touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/build_files/build_steps.patch
+++ b/build_files/build_steps.patch
@@ -1,15 +1,10 @@
---- build_steps.sh	2021-02-09 09:01:08.000000000 -0800
-+++ build_steps.sh.new	2021-02-09 09:03:41.000000000 -0800
-@@ -12,24 +12,23 @@
+--- build_steps.sh	2021-02-09 21:16:13.000000000 -0800
++++ build_steps.sh.new	2021-02-09 21:20:21.000000000 -0800
+@@ -12,19 +12,19 @@
  export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
  export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
  
 -cat >~/.condarc <<CONDARC
--
--conda-build:
-- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
--
--CONDARC
 +# cat >~/.condarc <<CONDARC
 +# 
 +# conda-build:
@@ -17,7 +12,13 @@
 +# 
 +# CONDARC
  
- conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
+-conda-build:
+- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+-
+-CONDARC
+-
+-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
++conda install -n ${CONDA_ENV} --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
  
  # set up the condarc
  setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -27,12 +28,15 @@
  
  # make the build number clobber
  make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+@@ -43,11 +43,11 @@
+     conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+-    validate_recipe_outputs "${FEEDSTOCK_NAME}"
++#     validate_recipe_outputs "${FEEDSTOCK_NAME}"
  
--
- if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-@@ -50,4 +49,4 @@
+     if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
      fi
  fi
  

--- a/build_files/build_steps.patch
+++ b/build_files/build_steps.patch
@@ -1,6 +1,6 @@
 --- build_steps.sh	2021-02-09 21:16:13.000000000 -0800
-+++ build_steps.sh.new	2021-02-09 21:20:21.000000000 -0800
-@@ -12,19 +12,19 @@
++++ build_steps.sh.new	2021-02-09 22:07:14.000000000 -0800
+@@ -12,19 +12,21 @@
  export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
  export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
  
@@ -14,11 +14,12 @@
  
 -conda-build:
 - root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
--
++conda install -n ${CONDA_ENV} --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
+ 
 -CONDARC
 -
 -conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
-+conda install -n ${CONDA_ENV} --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
++conda activate ${CONDA_ENV}
  
  # set up the condarc
  setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -28,7 +29,7 @@
  
  # make the build number clobber
  make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
-@@ -43,11 +43,11 @@
+@@ -43,11 +45,11 @@
      conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
          --suppress-variables ${EXTRA_CB_OPTIONS:-} \
          --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"

--- a/build_files/build_steps.patch
+++ b/build_files/build_steps.patch
@@ -1,6 +1,6 @@
---- build_steps.sh	2021-02-09 21:16:13.000000000 -0800
-+++ build_steps.sh.new	2021-02-09 22:07:14.000000000 -0800
-@@ -12,19 +12,21 @@
+--- build_steps.sh	2021-02-09 22:42:24.000000000 -0800
++++ build_steps.sh.new	2021-02-09 22:42:48.000000000 -0800
+@@ -12,19 +12,25 @@
  export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
  export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
  
@@ -14,11 +14,14 @@
  
 -conda-build:
 - root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
-+conda install -n ${CONDA_ENV} --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
++export PS1=
  
 -CONDARC
--
++. ${CONDA_DIR}/etc/profile.d/conda.sh
+ 
 -conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
++conda install -n ${CONDA_ENV} --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
++
 +conda activate ${CONDA_ENV}
  
  # set up the condarc
@@ -29,7 +32,7 @@
  
  # make the build number clobber
  make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
-@@ -43,11 +45,11 @@
+@@ -43,11 +49,11 @@
      conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
          --suppress-variables ${EXTRA_CB_OPTIONS:-} \
          --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"

--- a/build_files/build_steps.patch
+++ b/build_files/build_steps.patch
@@ -1,6 +1,6 @@
---- build_steps.sh	2021-02-09 22:42:24.000000000 -0800
-+++ build_steps.sh.new	2021-02-09 22:42:48.000000000 -0800
-@@ -12,19 +12,25 @@
+--- build_steps.sh	2021-02-12 09:46:18.000000000 -0800
++++ build_steps.sh.new	2021-02-12 09:47:21.000000000 -0800
+@@ -12,19 +12,27 @@
  export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
  export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
  
@@ -17,12 +17,13 @@
 +export PS1=
  
 -CONDARC
-+. ${CONDA_DIR}/etc/profile.d/conda.sh
- 
--conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
-+conda install -n ${CONDA_ENV} --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
++source ${CONDA_DIR}/etc/profile.d/conda.sh
 +
 +conda activate ${CONDA_ENV}
++
++conda info
+ 
+ conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
  
  # set up the condarc
  setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -32,12 +33,12 @@
  
  # make the build number clobber
  make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
-@@ -43,11 +49,11 @@
+@@ -43,11 +51,11 @@
      conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
          --suppress-variables ${EXTRA_CB_OPTIONS:-} \
          --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 -    validate_recipe_outputs "${FEEDSTOCK_NAME}"
-+#     validate_recipe_outputs "${FEEDSTOCK_NAME}"
++    # validate_recipe_outputs "${FEEDSTOCK_NAME}"
  
      if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
          upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/build_files/fix_conda_recipe.py
+++ b/build_files/fix_conda_recipe.py
@@ -14,16 +14,20 @@ for x in ilines:
             olines.append(x)
 
             processing = False
-        else:
-            continue
-    else:
-        if x == 'source:\n':
-            olines.append(x)
-            olines.append('  path: {}\n\n'.format(sys.argv[2]))
 
-            processing = True
-        else:
-            olines.append(x)
+        continue
+
+    if x == 'source:\n':
+        olines.append(x)
+        olines.append('  path: {}\n\n'.format(sys.argv[2]))
+
+        processing = True
+    elif 'number:' in x:
+        olines.append('  number: 0\n')
+    else:
+        olines.append(x)
+
+print(sys.argv[1])
 
 with open(sys.argv[1], 'w') as f:
     f.writelines(olines)

--- a/build_files/fix_conda_recipe.py
+++ b/build_files/fix_conda_recipe.py
@@ -1,0 +1,29 @@
+import sys
+
+with open(sys.argv[1]) as f:
+    ilines = f.readlines()
+
+print('Read {} lines'.format(len(ilines)))
+
+processing = False
+olines = []
+
+for x in ilines:
+    if processing:
+        if x == 'build:\n':
+            olines.append(x)
+
+            processing = False
+        else:
+            continue
+    else:
+        if x == 'source:\n':
+            olines.append(x)
+            olines.append('  path: {}\n\n'.format(sys.argv[2]))
+
+            processing = True
+        else:
+            olines.append(x)
+
+with open(sys.argv[1], 'w') as f:
+    f.writelines(olines)


### PR DESCRIPTION
This PR fixes a few build errors by simplifying the makefile and build process. We now build from the conda-forge feedstock to keep testing inline with the package that eventually gets built and released.