### PR TITLE
Fix mpi4py init

### DIFF
--- a/Lib/dataset.py
+++ b/Lib/dataset.py
@@ -34,6 +34,7 @@ from . import convention
 import warnings
 from collections import OrderedDict
 from six import string_types
+from .util import getenv_bool
 
 # Default is serial mode until setNetcdfUseParallelFlag(1) is called
 rk = 0
@@ -41,7 +42,13 @@ sz = 1
 Cdunif.CdunifSetNCFLAGS("use_parallel", 0)
 CdMpi = False
 
+mpi_disabled = getenv_bool("CDMS_NO_MPI", "False")
+
 try:
+    # skip trying to load mpi4py module
+    if mpi_disabled:
+        raise Exception()
+
     from mpi4py import rc
     rc.initialize = False
     from mpi4py import MPI
@@ -182,6 +189,9 @@ def setNetcdfUseParallelFlag(value):
        -------
        No return value.
     """
+    if mpi_disabled:
+        raise CDSMError("MPI support is disabled.")
+
     global CdMpi
     if value not in [True, False, 0, 1]:
         raise CDMSError(

--- a/Lib/tvariable.py
+++ b/Lib/tvariable.py
@@ -22,10 +22,16 @@ from .grid import createRectGrid, AbstractRectGrid
 from .hgrid import AbstractCurveGrid
 from .gengrid import AbstractGenericGrid
 from six import string_types, PY2
+from .util import getenv_bool
+
+mpi_disabled = getenv_bool("CDMS_NO_MPI", "False")
 
 # dist array support
 HAVE_MPI = False
 try:
+    if mpi_disabled:
+        raise Exception()
+
     from mpi4py import MPI
     HAVE_MPI = True
 except BaseException:

--- a/Lib/util.py
+++ b/Lib/util.py
@@ -1,6 +1,25 @@
+import os
+
+from .error import CDMSError
+
 def base_doc(base):
     def wrapper(fn):
         doc = getattr(base, fn.__name__).__doc__
         fn.__doc__ = doc
         return fn
     return wrapper
+
+valid_bool_str = ["true", "false"]
+
+def getenv_bool(name, default=None):
+    value = os.environ.get(name, default)
+
+    if value is None:
+        raise CDMSError("{!r} was not set".format(name))
+
+    if value.lower() not in valid_bool_str:
+        raise CDMSError(
+            "{!r} is not a valid value for {!r}, allowed values: {!r}".format(
+                value, name, valid_bool_str))
+
+    return True if value.lower() == "true" else False

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ clean-docs:
 .PHONY: test
 test: ENV := test
 test: CHANNELS := -c file://$(LOCAL_CHANNEL_DIR) -c conda-forge -c cdat/label/nightly
+test: CONDA_TEST_PACKAGES := mpi4py
 test: create-conda-env
 	[[ ! -e "$(TEST_OUTPUT_DIR)" ]] && mkdir -p $(TEST_OUTPUT_DIR) || true
 
@@ -143,7 +144,7 @@ test: create-conda-env
 		$(CONDA_TEST_PACKAGES); \
 		conda info; \
 		conda list --explicit > $(TEST_OUTPUT_DIR)/environment.txt; \
-		python run_tests.py -H -v2 -n 1
+		python run_tests.py -H -v2 -n 1 | tee test.log
 
 	cp -rf $(PWD)/tests_html $(TEST_OUTPUT_DIR)/
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1,12 +1,14 @@
 import sys
+import functools
 
 import unittest
 
 def revert_modules(func):
-    def wrapper():
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
         before = set(sys.modules)
 
-        func()
+        func(*args, **kwargs)
 
         after = set(sys.modules)
 
@@ -16,13 +18,13 @@ def revert_modules(func):
     return wrapper
 
 class TestMPI(unittest.TestCase):
-    # @revert_modules
+    @revert_modules
     def test_default_mpi(self):
         from cdms2 import dataset
 
         assert hasattr(dataset, "MPI")
 
-    # @revert_modules
+    @revert_modules
     def test_disable_mpi(self):
         import os
         os.environ["CDMS_NO_MPI"] = "true"

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1,0 +1,32 @@
+import sys
+
+import unittest
+
+def revert_modules(func):
+    def wrapper():
+        before = set(sys.modules)
+
+        func()
+
+        after = set(sys.modules)
+
+        for x in after-before:
+            del sys.modules[x]
+
+    return wrapper
+
+class TestMPI(unittest.TestCase):
+    # @revert_modules
+    def test_default_mpi(self):
+        from cdms2 import dataset
+
+        assert hasattr(dataset, "MPI")
+
+    # @revert_modules
+    def test_disable_mpi(self):
+        import os
+        os.environ["CDMS_NO_MPI"] = "true"
+
+        from cdms2 import dataset
+
+        assert not hasattr(dataset, "MPI")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,25 @@
+import os
+import contextlib
+
+import unittest
+from unittest.mock import patch
+
+from cdms2 import util
+from cdms2 import CDMSError
+
+class TestUtil(unittest.TestCase):
+    def test_getenv_bool(self):
+        with self.assertRaises(CDMSError):
+            util.getenv_bool("TEST")
+
+        with patch.dict(os.environ, {"TEST": "true"}):
+            value = util.getenv_bool("TEST")
+
+        assert value == True
+
+    def test_getenv_bool_invalid(self):
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch.dict(os.environ, {"TEST": "1"}))
+            stack.enter_context(self.assertRaises(CDMSError))
+
+            util.getenv_bool("TEST")


### PR DESCRIPTION
Fixes #425 

Adds environment variable `CDMS_NO_MPI`. If `mpi4py` is installed and the environment variable is set then `cdms2` will not try and initialize MPI.