### PR TITLE
fix issue #416 by adding more integer type checks

### DIFF
--- a/Lib/avariable.py
+++ b/Lib/avariable.py
@@ -1490,7 +1490,7 @@ avariable.regrid: We chose regridMethod = %s for you among the following choices
         slicelist = []
         for i in range(self.rank()):
             key = speclist[i]
-            if isinstance(key, int):  # x[i]
+            if isinstance(key, (int, numpy.int32, numpy.int64)):  # x[i]
                 slicelist.append(slice(key, key + 1))
             elif isinstance(key, slice):  # x[i:j:k]
                 slicelist.append(key)


### PR DESCRIPTION
Attempt to fix issue https://github.com/CDAT/cdms/issues/416.

Integers of type `numpy.int64` would fail the type check
`isinstance(key, int)` in `specs2slices()` in avariable.py.

Change to `isinstance(key, (int, numpy.int32, numpy.int64))` to fix
this.