### PR TITLE
Switch from circleci to gh actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Cache data
         uses: actions/cache@v2.1.5
         env:
-          CACHE_NUMBER: 1
+          CACHE_NUMBER: 2
         with:
           path: /usr/share/miniconda3/envs/test/share/cdat/sample_data
           key:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,10 +18,8 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        py: [3.6]
-        # os: [ubuntu-latest,macos-latest]
-        # py: [3.6,3.7,3.8,3.9]
+        os: [ubuntu-latest,macos-latest]
+        py: [3.6,3.7,3.8,3.9]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,9 +47,9 @@ jobs:
       - name: Cache data
         uses: actions/cache@v2.1.5
         env:
-          CACHE_NUMBER: 3
+          CACHE_NUMBER: 4
         with:
-          path: ~/envs/tests/share/cdat/sample_data
+          path: ~/envs/test/share/cdat/sample_data
           key:
             test-data-${{ env.CACHE_NUMBER }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,5 +60,6 @@ jobs:
           python setup.py install
 
       - name: run tests
+        continue-on-error: true
         run: |
           python run_tests.py -v 2 -n 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,6 +61,6 @@ jobs:
 
       - name: run tests
         run: |
-          pytest -vvv -n auto --ignore tests/test_forecast_io.py
+          pytest -vvv tests/ -n auto --ignore tests/test_forecast_io.py
 
           pytest -vvv tests/test_forecast_io.py

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,6 +41,11 @@ jobs:
           miniforge-variant: Mambaforge
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
 
+      - name: Fix conda test data permissions
+        run: |
+          sudo mkdir -p /usr/share/miniconda3/envs/test/share/cdat/sample_data
+          sudo chmod -R a+rwx /usr/share/miniconda3/envs/test/share/cdat/sample_data
+
       - name: Cache data
         uses: actions/cache@v2.1.5
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Cache data
         uses: actions/cache@v2.1.5
         env:
-          CACHE_NUMBER: 0
+          CACHE_NUMBER: 1
         with:
           path: /usr/share/miniconda3/envs/test/share/cdat/sample_data
           key:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,5 @@ jobs:
           python setup.py install
 
       - name: run tests
-        continue-on-error: true
         run: |
           python run_tests.py -v 2 -n 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,10 @@
+name: Build workflow
+
 on:
+  push:
+    branches:
+      - master
+
   pull_request:
     branches:
       - master
@@ -42,4 +48,4 @@ jobs:
 
       - name: run tests
         run: |
-          python run_tests.py
+          python run_tests.py -v 2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,4 +48,4 @@ jobs:
 
       - name: run tests
         run: |
-          python run_tests.py -v 2
+          python run_tests.py -v 2 -n 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,12 +10,15 @@ on:
       - master
 
 jobs:
-  setup_conda:
-    name: Build conda package
-    runs-on: ubuntu-latest
+  test_package:
+    name: Test CDMS2 package
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -l {0}
+    strategy:
+      matrix:
+        os: [ubuntu-latest,macos-latest]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,4 +61,6 @@ jobs:
 
       - name: run tests
         run: |
-          python run_tests.py -v 2 -n 1
+          pytest -vvv -n auto --ignore tests/test_forecast_io.py
+
+          pytest -vvv tests/test_forecast_io.py

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,15 @@ jobs:
           miniforge-variant: Mambaforge
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
 
+      - name: Cache data
+        uses: actions/cache@v2
+        env:
+          CACHE_NUMBER: 0
+        with:
+          path: /usr/share/miniconda3/envs/test/share/cdat/sample_data
+          key:
+            test-data-${{ env.CACHE_NUMBER }}
+
       - name: conda info
         run: |
           conda info

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,8 +18,10 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        os: [ubuntu-latest,macos-latest]
-        py: [3.6,3.7,3.8,3.9]
+        os: [ubuntu-latest]
+        py: [3.6]
+        # os: [ubuntu-latest,macos-latest]
+        # py: [3.6,3.7,3.8,3.9]
     steps:
       - uses: actions/checkout@v2
 
@@ -40,18 +42,14 @@ jobs:
           auto-activate-base: false
           miniforge-variant: Mambaforge
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-
-      - name: Fix conda test data permissions
-        run: |
-          sudo mkdir -p /usr/share/miniconda3/envs/test/share/cdat/sample_data
-          sudo chmod -R a+rwx /usr/share/miniconda3/envs/test/share/cdat/sample_data
+          condarc-file: condarc
 
       - name: Cache data
         uses: actions/cache@v2.1.5
         env:
-          CACHE_NUMBER: 2
+          CACHE_NUMBER: 3
         with:
-          path: /usr/share/miniconda3/envs/test/share/cdat/sample_data
+          path: ~/envs/tests/share/cdat/sample_data
           key:
             test-data-${{ env.CACHE_NUMBER }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest,macos-latest]
+        py: [3.6,3.7,3.8,3.9]
     steps:
       - uses: actions/checkout@v2
 
@@ -35,7 +36,7 @@ jobs:
         with:
           activate-environment: test
           environment-file: test-environment.yml
-          python-version: 3.6
+          python-version: ${{ matrix.py }}
           auto-activate-base: false
           miniforge-variant: Mambaforge
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.5
         env:
           CACHE_NUMBER: 1
         with:
@@ -42,7 +42,7 @@ jobs:
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
 
       - name: Cache data
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.5
         env:
           CACHE_NUMBER: 0
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Setup conda
     runs-on: ubuntu-latest
     steps:
-      - uses: conda-incubator/setup-miniconda
+      - uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           python-version: 3.6
           miniforge-variant: Mambaforge

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  setup_conda:
+    name: Setup conda
+    runs-on: ubuntu-latest
+    steps:
+      - uses: conda-incubator/setup-miniconda
+        with:
+          python-version: 3.6
+          miniforge-variant: Mambaforge
+      - name: conda info
+        run: |
+          conda info

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,13 +5,28 @@ on:
 
 jobs:
   setup_conda:
-    name: Setup conda
+    name: Build conda package
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache conda
+        uses: actions/cache@v2
+        env:
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('test-environment.yml') }}
+
       - uses: conda-incubator/setup-miniconda@v2.1.1
         with:
+          activate-environment: test
+          environment-file: test-environment.yml
           python-version: 3.6
+          auto-activate-base: false
           miniforge-variant: Mambaforge
+
       - name: conda info
         run: |
           conda info

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,9 @@ jobs:
   setup_conda:
     name: Build conda package
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,3 +30,10 @@ jobs:
       - name: conda info
         run: |
           conda info
+          conda list
+
+      - name: install package
+        run: |
+          python setup.py install
+
+          python -c "import cdms2"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,4 +40,6 @@ jobs:
         run: |
           python setup.py install
 
-          python -c "import cdms2"
+      - name: run tests
+        run: |
+          python run_tests.py

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Cache conda
         uses: actions/cache@v2
         env:
-          CACHE_NUMBER: 0
+          CACHE_NUMBER: 1
         with:
           path: ~/conda_pkgs_dir
           key:
@@ -29,6 +29,7 @@ jobs:
           python-version: 3.6
           auto-activate-base: false
           miniforge-variant: Mambaforge
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
 
       - name: conda info
         run: |

--- a/Lib/dataset.py
+++ b/Lib/dataset.py
@@ -2166,7 +2166,6 @@ class CdmsFile(CdmsObj, cuDataset):
         if _showCompressWarnings:
             if (Cdunif.CdunifGetNCFLAGS("shuffle") != 0) or (Cdunif.CdunifGetNCFLAGS(
                     "deflate") != 0) or (Cdunif.CdunifGetNCFLAGS("deflate_level") != 0):
-                import warnings
                 warnings.warn("Files are written with compression and no shuffling\n" +
                               "You can query different values of compression using the functions:\n" +
                               "cdms2.getNetcdfShuffleFlag() returning 1 if shuffling is enabled, " +

--- a/condarc
+++ b/condarc
@@ -1,0 +1,2 @@
+envs_dirs:
+  - ~/envs

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,58 @@
+import hashlib
+import os
+import sys
+from urllib.parse import urljoin
+
+import pytest
+import requests
+
+TEST_DATA_URL = "https://cdat.llnl.gov/cdat/sample_data/"
+
+def pytest_sessionstart(session):
+    download_all_test_data()
+
+def download_all_test_data():
+    for x in ["test_big_data_files.txt", "test_data_files.txt"]:
+        download_test_data(x)
+
+def download_test_data(test_data_info):
+    test_data_info_path = os.path.join("share", test_data_info)
+    test_data_local_path = os.path.join(sys.prefix, "share", "cdat",
+                                        "sample_data")
+
+    if not os.path.exists(test_data_local_path):
+        os.makedirs(test_data_local_path)
+
+    with open(test_data_info_path) as fd:
+        data = fd.readlines()
+
+    for x in data[1:]:
+        md5, name = x.split()
+
+        local_file = os.path.join(test_data_local_path, name)
+
+        remote_url = urljoin(TEST_DATA_URL, name)
+
+        if os.path.exists(local_file):
+            print(f"Skipping {remote_url}, already exists")
+
+            continue
+
+        print(f"Downloading {remote_url} to {local_file}")
+
+        response = requests.get(remote_url, stream=True)
+
+        response.raise_for_status()
+
+        m = hashlib.md5()
+
+        with open(local_file, "wb") as fd:
+            for chunk in response.iter_content(2048):
+                m.update(chunk)
+
+                fd.write(chunk)
+
+        assert m.hexdigest() == md5, f"Missmatch hash for {remote_url!r}"
+
+if __name__ == "__main__":
+    download_all_test_data()

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - openblas
   - pytest
   - testsrunner
+  - pytest
+  - pytest-xdist

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -1,0 +1,19 @@
+name: test
+channels:
+  - conda-forge
+  - cdat/label/nightly
+  - defaults
+dependencies:
+  - cdat_info
+  - libcdms
+  - libdrs_f
+  - libdrs
+  - cdtime
+  - lazy-object-proxy
+  - libnetcdf
+  - libnetcdf * nompi_*
+  - libcf
+  - distarray
+  - esmf
+  - esmpy
+  - openblas

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -17,3 +17,5 @@ dependencies:
   - esmf
   - esmpy
   - openblas
+  - pytest
+  - testsrunner

--- a/tests/test_CDMSBounds.py
+++ b/tests/test_CDMSBounds.py
@@ -3,6 +3,7 @@ import cdms2
 import unittest
 import numpy
 import os
+import uuid
 
 
 class TestCDMSAutobounds(unittest.TestCase):
@@ -10,7 +11,9 @@ class TestCDMSAutobounds(unittest.TestCase):
     def createFile(self, minLon, maxLon, offset):
         # Create a test netCDF file and load it with one grid of data.
         #
-        testFile = cdms2.open('testFile.nc', 'w')
+        uid = str(uuid.uuid4())[:8]
+        self.filename = f"testFile-{uid}.nc"
+        testFile = cdms2.open(self.filename, 'w')
         latitudes = numpy.linspace(-89.975, 89.975,
                                    num=3600, dtype=numpy.float32)
 
@@ -47,7 +50,7 @@ class TestCDMSAutobounds(unittest.TestCase):
         cdms2.setAutoBounds('on')
 
     def teardown(self):
-        os.remove("testFile.nc")
+        os.remove(self.filename)
 
     def test_Bounds10th(self):
         exponent = -10
@@ -55,7 +58,7 @@ class TestCDMSAutobounds(unittest.TestCase):
         self.createFile(-180, 180, offset)
         # Open the test file and get the CDMS2 longitude axis.
         #
-        testFile = cdms2.open('testFile.nc')
+        testFile = cdms2.open(self.filename)
         var = testFile.variables['tos']
         axes = var.getAxisList()
         for axis in axes:
@@ -66,7 +69,7 @@ class TestCDMSAutobounds(unittest.TestCase):
         self.assertAlmostEqual(bounds[0, 0], -179.999031067, 5)
         self.assertEqual(bounds[-1, 1], 180.00096893310547)
 #        self.assertAlmostEqual(bounds[-1, 1], 180.000984192, 5)
-        os.remove('testFile.nc')
+        os.remove(self.filename)
 
     def test_BoundsReverse11th(self):
         exponent = -11
@@ -74,7 +77,7 @@ class TestCDMSAutobounds(unittest.TestCase):
         self.createFile(180, -180, offset)
         # Open the test file and get the CDMS2 longitude axis.
         #
-        testFile = cdms2.open('testFile.nc')
+        testFile = cdms2.open(self.filename)
         var = testFile.variables['tos']
         axes = var.getAxisList()
         for axis in axes:
@@ -84,7 +87,7 @@ class TestCDMSAutobounds(unittest.TestCase):
         bounds = axis.getBounds()
         self.assertEqual(bounds[0, 0], 180.0)
         self.assertEqual(bounds[-1, 1], -180.0)
-        os.remove('testFile.nc')
+        os.remove(self.filename)
 
     def test_Bounds11th(self):
         exponent = -11
@@ -92,7 +95,7 @@ class TestCDMSAutobounds(unittest.TestCase):
         self.createFile(-180, 180, offset)
         # Open the test file and get the CDMS2 longitude axis.
         #
-        testFile = cdms2.open('testFile.nc')
+        testFile = cdms2.open(self.filename)
         var = testFile.variables['tos']
         axes = var.getAxisList()
         for axis in axes:
@@ -102,7 +105,7 @@ class TestCDMSAutobounds(unittest.TestCase):
         bounds = axis.getBounds()
         self.assertEqual(bounds[0, 0], -180.0)
         self.assertEqual(bounds[-1, 1], 180.0)
-        os.remove('testFile.nc')
+        os.remove(self.filename)
 
     def test_BoundsPolar(self):
         f=cdms2.open(cdat_info.get_sampledata_path() + "/stereographic.nc")

--- a/tests/test_cdscan.py
+++ b/tests/test_cdscan.py
@@ -26,8 +26,8 @@ def diffElements(el1, el2):
         if el2.get(k) != el1.get(k):
             return el1.get(k), el2.get(k)
 
-    el1_kids = el1.getchildren()
-    el2_kids = el2.getchildren()
+    el1_kids = list(el1)
+    el2_kids = list(el2)
     if len(el1_kids) != len(el2_kids):
         return "%d children" % len(el1_kids), "%d children" % len(el2_kids)
 


### PR DESCRIPTION
Switches unittesting from circleci to gh actions. The overall testing strategy has changed, in the past conda packages for linux/macos for python 3.6, 3.7, 3.8, and 3.9 were built. Now cdms is still tested on the same platforms and python versions except conda packages are no longer built. Rather a conda environment is created, the package is installed and unittesta are run. Building conda packages is left for the conda-forge process to manage. 

This change has drastically reduced the time it takes to test a PR.