### PR TITLE
Disable mpi4py regrid2 cdscan

### DIFF
--- a/Lib/cdscan.py
+++ b/Lib/cdscan.py
@@ -18,6 +18,7 @@ from functools import reduce
 from cdms2.error import CDMSError
 from collections import OrderedDict
 from six import string_types
+from cdsm2.util import getenv_bool
 usage = """Usage:
     cdscan [options] <files>
 
@@ -1840,7 +1841,12 @@ def main(argv):
 # ------------------------------------------------------------------------
 if __name__ == '__main__':
     main(sys.argv)
+    mpi_disabled = getenv_bool("CDMS_NO_MPI", "False")
     try:
+        # skip trying to load mpi4py module
+        if mpi_disabled:
+            raise Exception()
+
         from mpi4py import MPI
         comm = MPI.Comm.Get_parent()
         comm.send('done', dest=0)

--- a/Lib/cdscan.py
+++ b/Lib/cdscan.py
@@ -18,7 +18,7 @@ from functools import reduce
 from cdms2.error import CDMSError
 from collections import OrderedDict
 from six import string_types
-from cdsm2.util import getenv_bool
+from cdms2.util import getenv_bool
 usage = """Usage:
     cdscan [options] <files>
 

--- a/regrid2/Lib/esmf.py
+++ b/regrid2/Lib/esmf.py
@@ -18,6 +18,9 @@ from regrid2 import RegridError
 import ESMF
 from functools import reduce
 
+from .util import getenv_bool
+
+
 # constants
 R8 = ESMF.TypeKind.R8
 R4 = ESMF.TypeKind.R4
@@ -463,7 +466,13 @@ class EsmfStructField:
         # communicator
         self.comm = None
 
+        mpi_disabled = getenv_bool("CDMS_NO_MPI", "False")
+
         try:
+            # skip trying to load mpi4py module
+            if mpi_disabled:
+                raise Exception()
+
             from mpi4py import MPI
             self.comm = MPI.COMM_WORLD
         except BaseException:

--- a/regrid2/Lib/mvESMFRegrid.py
+++ b/regrid2/Lib/mvESMFRegrid.py
@@ -22,9 +22,16 @@ try:
 except Exception:
     os.environ['MPICH_INTERFACE_HOSTNAME'] = 'localhost'
 
+from .util import getenv_bool
+
 ESMF.Manager(debug=False)
 HAVE_MPI = False
+mpi_disabled = getenv_bool("CDMS_NO_MPI", "False")
+
 try:
+    # skip trying to load mpi4py module
+    if mpi_disabled:
+        raise Exception()
     from mpi4py import MPI
     HAVE_MPI = True
 except BaseException:


### PR DESCRIPTION
This merge optionally disables any attempts to import `mpi4py` in `regrid2` and `cdscan` with an environment flag, `CDMS_NO_MPI=True`.   This is similar to what was done previously for the `cdms2` package.

These changes correspond to the patches in https://github.com/conda-forge/cdms2-feedstock/pull/69