### PR TITLE
Fix disabling of mpi4py in cdms2.dataset

### DIFF
--- a/Lib/dataset.py
+++ b/Lib/dataset.py
@@ -189,9 +189,6 @@ def setNetcdfUseParallelFlag(value):
        -------
        No return value.
     """
-    if mpi_disabled:
-        raise CDSMError("MPI support is disabled.")
-
     global CdMpi
     if value not in [True, False, 0, 1]:
         raise CDMSError(
@@ -199,6 +196,9 @@ def setNetcdfUseParallelFlag(value):
     if value in [0, False]:
         Cdunif.CdunifSetNCFLAGS("use_parallel", 0)
     else:
+        if mpi_disabled:
+            raise CDMSError("MPI support is disabled.")
+
         Cdunif.CdunifSetNCFLAGS("use_parallel", 1)
         CdMpi = True
         if not MPI.Is_initialized():


### PR DESCRIPTION
For `cdscan` to work when MPI is disabled, we need to be able to call `setNetcdfUseParallelFlag(0)`.  Before this merge, this call attempted to raise an error but there was a typo in the error name (`CDSMError` instead of `CDMSError`), causing added confusion.  We only want to raise an error if the code is attempting to enable parallel NetCDF usage but MPI is disabled.